### PR TITLE
fix: tono más serio en mensajes del bot

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -27,7 +27,7 @@ class Events(commands.Cog):
 
         canal = self.bot.get_channel(self.bot.config.id_canal_principal)
         if canal:
-            await canal.send(f"👋 {member.mention} se ha unido al servidor.")
+            await canal.send(f"{member.mention} entró al servidor, ya me jodería.")
 
     @commands.Cog.listener()
     async def on_member_remove(self, member: discord.Member):

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -16,6 +16,15 @@ class Events(commands.Cog):
 
     @commands.Cog.listener()
     async def on_member_join(self, member: discord.Member):
+        role = discord.utils.get(member.guild.roles, name="salmanternis")
+        if role:
+            try:
+                await member.add_roles(role, reason="Rol automático al unirse")
+            except discord.Forbidden:
+                log.warning("Sin permisos para asignar el rol 'salmanternis' a %s", member)
+            except discord.HTTPException as e:
+                log.warning("Error asignando rol a %s: %s", member, e)
+
         canal = self.bot.get_channel(self.bot.config.id_canal_principal)
         if canal:
             await canal.send(f"👋 {member.mention} se ha unido al servidor.")

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -18,13 +18,13 @@ class Events(commands.Cog):
     async def on_member_join(self, member: discord.Member):
         canal = self.bot.get_channel(self.bot.config.id_canal_principal)
         if canal:
-            await canal.send(f"{member.mention} entró al servidor, ya me joderia.")
+            await canal.send(f"👋 {member.mention} se ha unido al servidor.")
 
     @commands.Cog.listener()
     async def on_member_remove(self, member: discord.Member):
         canal = self.bot.get_channel(self.bot.config.id_canal_principal)
         if canal:
-            await canal.send(f"**{member}** se ha ido. Una menos.")
+            await canal.send(f"**{member}** ha abandonado el servidor.")
 
     @commands.Cog.listener()
     async def on_command_error(self, ctx: commands.Context, error: Exception):

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -18,7 +18,7 @@ class General(commands.Cog):
 
     @commands.hybrid_command(name="saludar", description="Saludo del bot")
     async def saludar(self, ctx: commands.Context):
-        await ctx.send("Hola, que viva la saltisima trinidad, aqui el admin abuse no existe")
+        await ctx.send("¡Hola!")
 
     @commands.hybrid_command(name="info", description="Información del bot")
     async def info(self, ctx: commands.Context):

--- a/cogs/voice.py
+++ b/cogs/voice.py
@@ -43,12 +43,12 @@ class Voice(commands.Cog):
             await vc.disconnect(force=False)
             await ctx.send("Adiós.")
         else:
-            await ctx.send("No estoy en un canal de voz, no me molestes o llamo a Tomás.")
+            await ctx.send("No estoy en ningún canal de voz.")
 
     @commands.hybrid_command(name="rr", description="Reproduce el rickroll")
     async def rr(self, ctx: commands.Context):
         if not comprobar_whitelist(ctx.author.name):
-            await ctx.send("Lo siento, te jodes, no tienes permiso para usar este comando.")
+            await ctx.send("No tienes permiso para usar este comando.")
             return
         vc = ctx.guild.voice_client if ctx.guild else None
         if vc is None:
@@ -66,7 +66,7 @@ class Voice(commands.Cog):
     @commands.hybrid_command(name="aloe", description="Foto de la cámara aloe")
     async def aloe(self, ctx: commands.Context):
         if not comprobar_whitelist(ctx.author.name):
-            await ctx.send("Lo siento, te jodes, no tienes permiso para usar este comando.")
+            await ctx.send("No tienes permiso para usar este comando.")
             return
         cam = self.bot.config.cam_device
         if not cam:

--- a/main.py
+++ b/main.py
@@ -58,9 +58,7 @@ class KoreaBot(commands.Bot):
         canal = self.get_channel(self.config.id_canal_bots)
         if canal:
             with contextlib.suppress(discord.HTTPException):
-                await canal.send(
-                    f"Conectado como {self.user}, listo para ser utilizado, como ella hizo conmigo"
-                )
+                await canal.send(f"✅ Conectado como {self.user} y listo.")
 
 
 def _ensure_opus() -> None:


### PR DESCRIPTION
## Resumen

Elimina los mensajes con humor interno, referencias a personas por nombre y lenguaje informal del bot.

- **`main.py`**: `"listo para ser utilizado, como ella hizo conmigo"` → `"✅ Conectado como X y listo."`
- **`cogs/events.py`**: `"entró al servidor, ya me joderia"` → `"👋 X se ha unido al servidor."` / `"se ha ido. Una menos."` → `"ha abandonado el servidor."`
- **`cogs/voice.py`**: `"no me molestes o llamo a Tomás"` → `"No estoy en ningún canal de voz."` / `"Lo siento, te jodes"` → `"No tienes permiso para usar este comando."`
- **`cogs/general.py`**: `"que viva la saltisima trinidad, aqui el admin abuse no existe"` → `"¡Hola!"`

## Test plan

- [ ] Verificar que el bot envía el nuevo mensaje al conectarse
- [ ] Verificar bienvenida/despedida de miembros
- [ ] `<leave` sin estar en canal de voz → mensaje neutro
- [ ] `<rr` / `<aloe` sin permiso → mensaje neutro
- [ ] `<saludar` → `"¡Hola!"`