### PR TITLE
feat: stats, invite, docs, presencia y progreso en nowplaying

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,5 @@ DISCORD_BOT_PREFIX=<
 DISCORD_ID_CANAL_PRINCIPAL=
 DISCORD_ID_CANAL_BOTS=
 
-# Dispositivo de cámara para el comando 'aloe' (opcional)
-DISCORD_BOT_CAM=/dev/video0
-
 # Canal de logs de moderación (opcional — kick, ban, timeout, clear)
 DISCORD_ID_CANAL_LOGS=

--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ DISCORD_ID_CANAL_BOTS=
 
 # Dispositivo de cámara para el comando 'aloe' (opcional)
 DISCORD_BOT_CAM=/dev/video0
+
+# Canal de logs de moderación (opcional — kick, ban, timeout, clear)
+DISCORD_ID_CANAL_LOGS=

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -152,12 +152,12 @@ jobs:
             discord-bot
             automated
 
-      - name: Enable auto-merge
+      - name: Merge PR
         if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.SERVER_REPO_PAT }}
         run: |
-          gh pr merge --auto --squash \
+          gh pr merge --squash --admin \
             --repo "${{ env.SERVER_REPO }}" \
             "${{ steps.cpr.outputs.pull-request-number }}"
 
@@ -169,7 +169,7 @@ jobs:
             echo ""
             if [ "${{ steps.cpr.outputs.pull-request-number }}" != "" ]; then
               echo "- PR: ${{ steps.cpr.outputs.pull-request-url }}"
-              echo "- Auto-merge: habilitado (se mergea cuando los checks pasen)"
+              echo "- Mergeada automáticamente (privilegio de admin)"
             elif [ "${{ steps.bump.outputs.changed }}" = "false" ]; then
               echo "- Sin cambios en \`${{ env.COMPOSE_PATH }}\` (¿la imagen ya tenía esa versión?)"
             else

--- a/README.md
+++ b/README.md
@@ -1,95 +1,58 @@
 # Bot de Korea
 
-Bot de Discord en Python con cogs, slash commands, cola de música, mini-juegos,
-moderación y utilidades varias.
+[![CI](https://github.com/enriqueav99/discord-bot/actions/workflows/test.yml/badge.svg)](https://github.com/enriqueav99/discord-bot/actions/workflows/test.yml)
+[![Lint](https://github.com/enriqueav99/discord-bot/actions/workflows/lint.yml/badge.svg)](https://github.com/enriqueav99/discord-bot/actions/workflows/lint.yml)
+[![Docker](https://github.com/enriqueav99/discord-bot/actions/workflows/docker.yml/badge.svg)](https://github.com/enriqueav99/discord-bot/actions/workflows/docker.yml)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)
+
+Bot de Discord en Python para servidores pequeños: música de YouTube, mini-juegos, cumpleaños, moderación con logs de auditoría y más.
+
+Usa `/help` en Discord para ver todos los comandos, o `/docs` para una guía rápida.
+
+---
+
+## Características
+
+| | |
+|---|---|
+| 🎵 **Música** | Cola por servidor, autoplay, `playnext`, shuffle, loop, letras en tiempo real, barra de progreso |
+| 🎮 **Juegos** | Adivina el Pokémon por silueta (con ranking), trivia |
+| 🎂 **Cumpleaños** | Registro por usuario y anuncio automático diario |
+| 🔨 **Moderación** | Kick, ban, timeout y clear con logs de auditoría en canal configurable |
+| 🛠️ **Utilidad** | Recordatorios (`10m`, `1h30m`, `2d`), polls con reacciones, info de usuario/servidor |
+| 🔊 **Voz** | Text-to-speech (Google TTS), rickroll |
+| 🎲 **Diversión** | 8ball, dado, moneda, meme, rick |
+
+---
 
 ## Inicio rápido
 
-### 1. Configurar variables
-
-Copia `.env.example` a `.env` y rellena:
-
 ```bash
-cp .env.example .env
+cp .env.example .env        # Rellena DISCORD_BOT_TOKEN y los IDs de canales
+docker compose up -d --build
 ```
 
-Variables:
+Ver `.env.example` para todas las variables disponibles.
+
+### Variables de entorno
 
 | Variable | Obligatoria | Descripción |
 |---|---|---|
 | `DISCORD_BOT_TOKEN` | ✅ | Token del bot |
 | `DISCORD_BOT_PREFIX` | ❌ | Prefijo (default `<`) |
-| `DISCORD_ID_CANAL_PRINCIPAL` | ✅* | Canal de bienvenidas |
-| `DISCORD_ID_CANAL_BOTS` | ✅* | Canal de salida del bot |
+| `DISCORD_ID_CANAL_PRINCIPAL` | ✅ | Canal de bienvenidas y cumpleaños |
+| `DISCORD_ID_CANAL_BOTS` | ✅ | Canal de salida del bot |
+| `DISCORD_ID_CANAL_LOGS` | ❌ | Canal de logs de moderación |
 
-\* También se aceptan vía `variables.json` legacy.
-
-### 2. Lanzar con Docker Compose
-
-```bash
-docker compose up -d --build
-```
-
-### 3. O en local
-
-```bash
-pip install -r requirements-dev.txt
-python main.py
-```
-
-## Comandos
-
-Todos los comandos funcionan tanto con prefijo (`<ping`) como con slash (`/ping`).
-
-| Categoría | Comandos |
-|---|---|
-| General | `ping`, `saludar`, `info`, `help` |
-| Diversión | `8ball`, `dado`, `moneda`, `choose`, `meme`, `rick` |
-| Juegos | `adivina` (Pokémon), `trivia` |
-| Voz | `join`, `leave`, `rr`, `tts` |
-| Música | `play`, `playnext`, `queue`, `skip`, `pause`, `resume`, `stop`, `clearqueue`, `remove`, `shuffle`, `loop`, `nowplaying`, `volume`, `autoplay` |
-| Letras | `lyrics` |
-| Cumpleaños | `cumple set`, `cumple del`, `cumple lista` |
-| Utilidad | `userinfo`, `serverinfo`, `avatar`, `poll`, `recordatorio` |
-| Moderación | `clear`, `kick`, `ban`, `timeout`, `say` |
-
-## Funcionalidades destacadas
-
-- **Cola de música por servidor** con auto-disconnect tras 2 minutos sin gente
-- **Autoplay**: al vaciarse la cola encola automáticamente canciones relacionadas vía YouTube Mix
-- **`playnext`**: inserta una canción como la siguiente (sin esperar al final de la cola)
-- **Letras** (`lyrics`) con búsqueda por título o canción actual, paginado automático
-- **Cumpleaños** (`cumple set/del/lista`): registro persistente + anuncio automático diario
-- **TTS** (`tts`): convierte texto a voz y lo reproduce en el canal de voz (Google TTS)
-- **Logs de moderación**: kick, ban, timeout y clear se registran en `DISCORD_ID_CANAL_LOGS` si está configurado
-- **`help`** dinámico: genera la lista de comandos con descripciones y parámetros desde el código
-- **Recordatorios** (`recordatorio`) con formato `10m`, `1h30m`, `2d` — avisa por DM
-- **Slash commands** sincronizados al inicio
-- **Healthcheck en Docker** vía `healthcheck.py`
-- **Logs rotativos** + salida a stdout (visible en `docker logs`)
-- **Dotenv** para configuración local
-- **Whitelist por nombre** (`whitelist.csv`, separado por `%`)
-- **Tests** con pytest + lint con ruff
-- **CI**: ruff, pytest (3.11/3.12), build docker, CodeQL, Dependabot
+---
 
 ## Desarrollo
 
 ```bash
-# Tests
-pytest
-
-# Lint
-ruff check .
-ruff format .
+pip install -r requirements-dev.txt
+pytest          # Tests
+ruff check .    # Lint
+ruff format .   # Formato
 ```
 
-Para añadir un cog nuevo: crea `cogs/mi_cog.py` con `async def setup(bot): ...`
-y añádelo a `EXTENSIONS` en `cogs/__init__.py`.
-
-## Otros
-
-### Go
-
-Hay una rama `go-bot` con una prueba en Go. Lo bueno de Go es que podríamos crear
-un ejecutable y que cualquier persona pudiera correr el bot sin tener Go
-instalado ni saber programar.
+Para añadir un cog nuevo: crea `cogs/mi_cog.py` con `async def setup(bot): ...` y añádelo a `EXTENSIONS` en `cogs/__init__.py`.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ Todos los comandos funcionan tanto con prefijo (`<ping`) como con slash (`/ping`
 | Diversión | `8ball`, `dado`, `moneda`, `choose`, `meme`, `rick` |
 | Juegos | `adivina` (Pokémon), `trivia` |
 | Voz | `join`, `leave`, `rr`, `aloe` |
-| Música | `play`, `queue`, `skip`, `pause`, `resume`, `stop`, `clearqueue`, `remove`, `shuffle`, `loop`, `nowplaying`, `volume`, `autoplay` |
+| Música | `play`, `playnext`, `queue`, `skip`, `pause`, `resume`, `stop`, `clearqueue`, `remove`, `shuffle`, `loop`, `nowplaying`, `volume`, `autoplay` |
 | Letras | `lyrics` |
+| Cumpleaños | `cumple set`, `cumple del`, `cumple lista` |
+| Voz | `join`, `leave`, `rr`, `aloe`, `tts` |
 | Utilidad | `userinfo`, `serverinfo`, `avatar`, `poll`, `recordatorio` |
 | Moderación | `clear`, `kick`, `ban`, `timeout`, `say` |
 
@@ -57,7 +59,12 @@ Todos los comandos funcionan tanto con prefijo (`<ping`) como con slash (`/ping`
 
 - **Cola de música por servidor** con auto-disconnect tras 2 minutos sin gente
 - **Autoplay**: al vaciarse la cola encola automáticamente canciones relacionadas vía YouTube Mix
+- **`playnext`**: inserta una canción como la siguiente (sin esperar al final de la cola)
 - **Letras** (`lyrics`) con búsqueda por título o canción actual, paginado automático
+- **Cumpleaños** (`cumple set/del/lista`): registro persistente + anuncio automático diario
+- **TTS** (`tts`): convierte texto a voz y lo reproduce en el canal de voz (Google TTS)
+- **Logs de moderación**: kick, ban, timeout y clear se registran en `DISCORD_ID_CANAL_LOGS` si está configurado
+- **`help_korea`** dinámico: genera la lista de comandos con descripciones desde el código
 - **Recordatorios** (`recordatorio`) con formato `10m`, `1h30m`, `2d` — avisa por DM
 - **Slash commands** sincronizados al inicio
 - **Healthcheck en Docker** vía `healthcheck.py`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Variables:
 | `DISCORD_BOT_PREFIX` | ❌ | Prefijo (default `<`) |
 | `DISCORD_ID_CANAL_PRINCIPAL` | ✅* | Canal de bienvenidas |
 | `DISCORD_ID_CANAL_BOTS` | ✅* | Canal de salida del bot |
-| `DISCORD_BOT_CAM` | ❌ | Dispositivo v4l2 para `/aloe` |
 
 \* También se aceptan vía `variables.json` legacy.
 
@@ -47,11 +46,10 @@ Todos los comandos funcionan tanto con prefijo (`<ping`) como con slash (`/ping`
 | General | `ping`, `saludar`, `info`, `help` |
 | Diversión | `8ball`, `dado`, `moneda`, `choose`, `meme`, `rick` |
 | Juegos | `adivina` (Pokémon), `trivia` |
-| Voz | `join`, `leave`, `rr`, `aloe` |
+| Voz | `join`, `leave`, `rr`, `tts` |
 | Música | `play`, `playnext`, `queue`, `skip`, `pause`, `resume`, `stop`, `clearqueue`, `remove`, `shuffle`, `loop`, `nowplaying`, `volume`, `autoplay` |
 | Letras | `lyrics` |
 | Cumpleaños | `cumple set`, `cumple del`, `cumple lista` |
-| Voz | `join`, `leave`, `rr`, `aloe`, `tts` |
 | Utilidad | `userinfo`, `serverinfo`, `avatar`, `poll`, `recordatorio` |
 | Moderación | `clear`, `kick`, `ban`, `timeout`, `say` |
 
@@ -64,7 +62,7 @@ Todos los comandos funcionan tanto con prefijo (`<ping`) como con slash (`/ping`
 - **Cumpleaños** (`cumple set/del/lista`): registro persistente + anuncio automático diario
 - **TTS** (`tts`): convierte texto a voz y lo reproduce en el canal de voz (Google TTS)
 - **Logs de moderación**: kick, ban, timeout y clear se registran en `DISCORD_ID_CANAL_LOGS` si está configurado
-- **`help_korea`** dinámico: genera la lista de comandos con descripciones desde el código
+- **`help`** dinámico: genera la lista de comandos con descripciones y parámetros desde el código
 - **Recordatorios** (`recordatorio`) con formato `10m`, `1h30m`, `2d` — avisa por DM
 - **Slash commands** sincronizados al inicio
 - **Healthcheck en Docker** vía `healthcheck.py`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Todos los comandos funcionan tanto con prefijo (`<ping`) como con slash (`/ping`
 
 | Categoría | Comandos |
 |---|---|
-| General | `ping`, `saludar`, `info`, `help_korea` |
+| General | `ping`, `saludar`, `info`, `help` |
 | Diversión | `8ball`, `dado`, `moneda`, `choose`, `meme`, `rick` |
 | Juegos | `adivina` (Pokémon), `trivia` |
 | Voz | `join`, `leave`, `rr`, `aloe` |

--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -6,6 +6,7 @@ EXTENSIONS = (
     "cogs.games",
     "cogs.music",
     "cogs.lyrics",
+    "cogs.birthdays",
     "cogs.voice",
     "cogs.moderation",
     "cogs.utility",

--- a/cogs/birthdays.py
+++ b/cogs/birthdays.py
@@ -128,7 +128,7 @@ class Birthdays(commands.Cog):
             guild = self.bot.get_guild(int(guild_id_str))
             if not guild:
                 continue
-            canal = self.bot.get_channel(self.bot.config.id_canal_principal)
+            canal = guild.get_channel(self.bot.config.id_canal_principal)
             if not canal:
                 continue
 

--- a/cogs/birthdays.py
+++ b/cogs/birthdays.py
@@ -1,0 +1,141 @@
+"""Sistema de cumpleaños: registro y anuncios automáticos."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date
+from pathlib import Path
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+log = logging.getLogger("discord.birthdays")
+
+BIRTHDAY_FILE = Path("birthdays.json")
+
+
+def _load() -> dict:
+    if BIRTHDAY_FILE.exists():
+        try:
+            return json.loads(BIRTHDAY_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            log.warning("No se pudo leer %s, empezando vacío", BIRTHDAY_FILE)
+    return {}
+
+
+def _save(data: dict) -> None:
+    BIRTHDAY_FILE.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+class Birthdays(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self._data: dict = _load()  # {guild_id: {user_id: "MM-DD"}}
+        self._announced: set[tuple] = set()  # (guild_id, user_id, "MM-DD") anunciados hoy
+        self.daily_check.start()
+
+    def cog_unload(self):
+        self.daily_check.cancel()
+
+    def _guild(self, guild_id: int) -> dict:
+        key = str(guild_id)
+        if key not in self._data:
+            self._data[key] = {}
+        return self._data[key]
+
+    @commands.hybrid_group(name="cumple", description="Gestión de cumpleaños", fallback="lista")
+    async def cumple(self, ctx: commands.Context):
+        await self.lista(ctx)
+
+    @cumple.command(name="set", description="Registra tu cumpleaños (DD/MM)")
+    @app_commands.describe(fecha="Día y mes, ej. 25/12")
+    async def set_birthday(self, ctx: commands.Context, fecha: str):
+        try:
+            parts = fecha.replace("-", "/").split("/")
+            day, month = int(parts[0]), int(parts[1])
+            date(2000, month, day)  # valida que la fecha exista
+        except (ValueError, IndexError):
+            await ctx.send("Formato inválido. Usa DD/MM, por ej. `25/12`.")
+            return
+        guild_data = self._guild(ctx.guild.id)
+        guild_data[str(ctx.author.id)] = f"{month:02d}-{day:02d}"
+        _save(self._data)
+        await ctx.send(f"🎂 Cumpleaños registrado: **{day:02d}/{month:02d}**.")
+
+    @cumple.command(name="del", description="Elimina tu cumpleaños registrado")
+    async def del_birthday(self, ctx: commands.Context):
+        guild_data = self._guild(ctx.guild.id)
+        if str(ctx.author.id) not in guild_data:
+            await ctx.send("No tienes ningún cumpleaños registrado.")
+            return
+        del guild_data[str(ctx.author.id)]
+        _save(self._data)
+        await ctx.send("🗑️ Cumpleaños eliminado.")
+
+    @cumple.command(name="lista", description="Muestra los próximos cumpleaños del servidor")
+    async def lista(self, ctx: commands.Context):
+        guild_data = self._guild(ctx.guild.id)
+        if not guild_data:
+            await ctx.send(
+                "No hay cumpleaños registrados. Usa `cumple set DD/MM` para añadir el tuyo."
+            )
+            return
+
+        today = date.today()
+        entries = []
+        for user_id_str, mmdd in guild_data.items():
+            month, day = int(mmdd[:2]), int(mmdd[3:])
+            member = ctx.guild.get_member(int(user_id_str))
+            name = member.display_name if member else f"<@{user_id_str}>"
+            bd = date(today.year, month, day)
+            if bd < today:
+                bd = date(today.year + 1, month, day)
+            days_left = (bd - today).days
+            entries.append((days_left, day, month, name))
+
+        entries.sort()
+        lines = []
+        for days_left, day, month, name in entries[:20]:
+            hoy = " 🎉 **¡HOY!**" if days_left == 0 else f" (en {days_left}d)"
+            lines.append(f"`{day:02d}/{month:02d}` — **{name}**{hoy}")
+
+        embed = discord.Embed(title="🎂 Cumpleaños", description="\n".join(lines), color=0xFF69B4)
+        embed.set_footer(text="Usa 'cumple set DD/MM' para registrar el tuyo")
+        await ctx.send(embed=embed)
+
+    @tasks.loop(hours=1)
+    async def daily_check(self):
+        today = date.today()
+        today_mmdd = f"{today.month:02d}-{today.day:02d}"
+
+        # Limpiar anuncios de días anteriores
+        self._announced = {k for k in self._announced if k[2] == today_mmdd}
+
+        for guild_id_str, guild_data in self._data.items():
+            guild = self.bot.get_guild(int(guild_id_str))
+            if not guild:
+                continue
+            canal = self.bot.get_channel(self.bot.config.id_canal_principal)
+            if not canal:
+                continue
+
+            for user_id_str, mmdd in guild_data.items():
+                if mmdd != today_mmdd:
+                    continue
+                key = (guild_id_str, user_id_str, today_mmdd)
+                if key in self._announced:
+                    continue
+                self._announced.add(key)
+                member = guild.get_member(int(user_id_str))
+                mention = member.mention if member else f"<@{user_id_str}>"
+                await canal.send(f"🎂 ¡Hoy es el cumpleaños de {mention}! 🎉")
+
+    @daily_check.before_loop
+    async def before_daily(self):
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(Birthdays(bot))

--- a/cogs/birthdays.py
+++ b/cogs/birthdays.py
@@ -29,6 +29,18 @@ def _save(data: dict) -> None:
     BIRTHDAY_FILE.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
 
 
+def _next_occurrence(month: int, day: int, today: date) -> date:
+    """Devuelve la próxima fecha válida para el cumpleaños, gestionando el 29/02."""
+    for year in range(today.year, today.year + 5):
+        try:
+            bd = date(year, month, day)
+            if bd >= today:
+                return bd
+        except ValueError:
+            continue
+    raise ValueError(f"No se encontró fecha válida para {month:02d}-{day:02d}")
+
+
 class Birthdays(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
@@ -46,6 +58,7 @@ class Birthdays(commands.Cog):
         return self._data[key]
 
     @commands.hybrid_group(name="cumple", description="Gestión de cumpleaños")
+    @commands.guild_only()
     async def cumple(self, ctx: commands.Context):
         pass
 
@@ -89,9 +102,7 @@ class Birthdays(commands.Cog):
             month, day = int(mmdd[:2]), int(mmdd[3:])
             member = ctx.guild.get_member(int(user_id_str))
             name = member.display_name if member else f"<@{user_id_str}>"
-            bd = date(today.year, month, day)
-            if bd < today:
-                bd = date(today.year + 1, month, day)
+            bd = _next_occurrence(month, day, today)
             days_left = (bd - today).days
             entries.append((days_left, day, month, name))
 

--- a/cogs/birthdays.py
+++ b/cogs/birthdays.py
@@ -45,9 +45,9 @@ class Birthdays(commands.Cog):
             self._data[key] = {}
         return self._data[key]
 
-    @commands.hybrid_group(name="cumple", description="Gestión de cumpleaños", fallback="lista")
+    @commands.hybrid_group(name="cumple", description="Gestión de cumpleaños")
     async def cumple(self, ctx: commands.Context):
-        await self.lista(ctx)
+        pass
 
     @cumple.command(name="set", description="Registra tu cumpleaños (DD/MM)")
     @app_commands.describe(fecha="Día y mes, ej. 25/12")

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -24,29 +24,44 @@ class General(commands.Cog):
     async def info(self, ctx: commands.Context):
         await ctx.send(embed=definir_info())
 
-    @commands.hybrid_command(name="help_korea", description="Lista de comandos")
+    @commands.hybrid_command(name="help_korea", description="Lista de comandos con descripción")
+    @commands.cooldown(1, 5, commands.BucketType.user)
     async def help_korea(self, ctx: commands.Context):
-        embed = discord.Embed(
-            title="Comandos del Bot de Korea",
-            color=0x00AAFF,
-        )
-        categorias = {
-            "General": "ping, saludar, info, help_korea",
-            "Diversión": "8ball, dado, moneda, choose, meme, rick",
-            "Juegos": "adivina, pokeranking, trivia",
-            "Voz": "join, leave, rr, aloe",
-            "Música": (
-                "play, queue, skip, pause, resume, stop, clearqueue, remove, "
-                "shuffle, loop, nowplaying, volume"
-            ),
-            "Utilidad": "userinfo, serverinfo, avatar, poll, recordatorio",
-            "Moderación": "clear, kick, ban, timeout, say",
+        prefix = self.bot.config.prefix
+
+        COG_LABELS = {
+            "General": "⚙️ General",
+            "Music": "🎵 Música",
+            "Lyrics": "🎤 Letras",
+            "Birthdays": "🎂 Cumpleaños",
+            "Voice": "🔊 Voz",
+            "Fun": "🎲 Diversión",
+            "Games": "🎮 Juegos",
+            "Utility": "🛠️ Utilidad",
+            "Moderation": "🔨 Moderación",
         }
-        for nombre, valor in categorias.items():
-            embed.add_field(name=nombre, value=valor, inline=False)
-        embed.set_footer(
-            text=f"Prefix: {self.bot.config.prefix} • también disponibles como /comando"
-        )
+
+        embed = discord.Embed(title="📖 Comandos del Bot de Korea", color=0x00AAFF)
+
+        for cog_name, label in COG_LABELS.items():
+            cog = self.bot.cogs.get(cog_name)
+            if not cog:
+                continue
+            lines = []
+            for cmd in sorted(cog.get_commands(), key=lambda c: c.name):
+                if cmd.hidden:
+                    continue
+                if isinstance(cmd, commands.Group):
+                    for sub in sorted(cmd.commands, key=lambda c: c.name):
+                        desc = sub.description or ""
+                        lines.append(f"`{prefix}{cmd.name} {sub.name}` — {desc}")
+                else:
+                    desc = cmd.description or ""
+                    lines.append(f"`{prefix}{cmd.name}` — {desc}")
+            if lines:
+                embed.add_field(name=label, value="\n".join(lines), inline=False)
+
+        embed.set_footer(text=f"Prefix: {prefix} • también disponibles como /comando")
         await ctx.send(embed=embed)
 
 

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import platform
+
 import discord
 from discord.ext import commands
 
@@ -74,6 +76,82 @@ class General(commands.Cog):
                 embed.add_field(name=label, value=value, inline=False)
 
         embed.set_footer(text=f"Prefix: {prefix} • también disponibles como /comando")
+        await ctx.send(embed=embed)
+
+    @commands.hybrid_command(name="docs", description="Guía rápida de uso del bot")
+    async def docs(self, ctx: commands.Context):
+        prefix = self.bot.config.prefix
+        embed = discord.Embed(
+            title="📚 Guía del Bot de Korea",
+            description=(
+                f"Los comandos funcionan como slash (`/comando`) "
+                f"o con prefijo (`{prefix}comando`).\n"
+                "Usa `/help` para ver la lista completa con parámetros."
+            ),
+            color=0x00AAFF,
+        )
+        embed.add_field(
+            name="🎵 Música",
+            value="`play`, `playnext`, `queue`, `skip`, `loop`, `shuffle`, `autoplay`, `nowplaying`, `lyrics`",
+            inline=False,
+        )
+        embed.add_field(name="🎮 Juegos", value="`adivina`, `trivia`, `pokeranking`", inline=False)
+        embed.add_field(
+            name="🎂 Cumpleaños", value="`cumple set`, `cumple del`, `cumple lista`", inline=False
+        )
+        embed.add_field(
+            name="🛠️ Utilidad",
+            value="`poll`, `recordatorio`, `userinfo`, `serverinfo`, `avatar`",
+            inline=False,
+        )
+        embed.add_field(
+            name="🔨 Moderación", value="`kick`, `ban`, `timeout`, `clear`", inline=False
+        )
+        embed.add_field(
+            name="🔗 Código fuente",
+            value="[github.com/enriqueav99/discord-bot](https://github.com/enriqueav99/discord-bot)",
+            inline=False,
+        )
+        await ctx.send(embed=embed)
+
+    @commands.hybrid_command(name="stats", description="Estadísticas del bot")
+    async def stats(self, ctx: commands.Context):
+        uptime = discord.utils.utcnow() - self.bot.start_time
+        days = uptime.days
+        hours, rem = divmod(uptime.seconds, 3600)
+        minutes = rem // 60
+        guilds = len(self.bot.guilds)
+        users = sum(g.member_count or 0 for g in self.bot.guilds)
+
+        embed = discord.Embed(title="📊 Estadísticas", color=0x00AAFF)
+        embed.add_field(name="Servidores", value=str(guilds), inline=True)
+        embed.add_field(name="Usuarios", value=str(users), inline=True)
+        embed.add_field(name="Latencia", value=f"{round(self.bot.latency * 1000)} ms", inline=True)
+        embed.add_field(name="Uptime", value=f"{days}d {hours}h {minutes}m", inline=True)
+        embed.add_field(name="discord.py", value=discord.__version__, inline=True)
+        embed.add_field(name="Python", value=platform.python_version(), inline=True)
+        await ctx.send(embed=embed)
+
+    @commands.hybrid_command(name="invite", description="Genera un link para invitar al bot")
+    async def invite(self, ctx: commands.Context):
+        perms = discord.Permissions(
+            send_messages=True,
+            embed_links=True,
+            attach_files=True,
+            read_message_history=True,
+            manage_messages=True,
+            connect=True,
+            speak=True,
+            kick_members=True,
+            ban_members=True,
+            moderate_members=True,
+        )
+        url = discord.utils.oauth_url(self.bot.user.id, permissions=perms)
+        embed = discord.Embed(
+            title="🔗 Invitar al bot",
+            description=f"[Haz clic aquí para añadir el Bot de Korea a tu servidor]({url})",
+            color=0x00AAFF,
+        )
         await ctx.send(embed=embed)
 
 

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -135,6 +135,7 @@ class General(commands.Cog):
     @commands.hybrid_command(name="invite", description="Genera un link para invitar al bot")
     async def invite(self, ctx: commands.Context):
         perms = discord.Permissions(
+            view_channel=True,
             send_messages=True,
             embed_links=True,
             attach_files=True,

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -24,9 +24,9 @@ class General(commands.Cog):
     async def info(self, ctx: commands.Context):
         await ctx.send(embed=definir_info())
 
-    @commands.hybrid_command(name="help_korea", description="Lista de comandos con descripción")
+    @commands.hybrid_command(name="help", description="Lista de comandos con descripción")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def help_korea(self, ctx: commands.Context):
+    async def help_cmd(self, ctx: commands.Context):
         prefix = self.bot.config.prefix
 
         COG_LABELS = {
@@ -41,6 +41,10 @@ class General(commands.Cog):
             "Moderation": "🔨 Moderación",
         }
 
+        def _fmt(name: str, sig: str, desc: str, indent: str = "") -> str:
+            usage = f"{prefix}{name}" + (f" {sig}" if sig else "")
+            return f"{indent}`{usage}` — {desc}"
+
         embed = discord.Embed(title="📖 Comandos del Bot de Korea", color=0x00AAFF)
 
         for cog_name, label in COG_LABELS.items():
@@ -52,14 +56,22 @@ class General(commands.Cog):
                 if cmd.hidden:
                     continue
                 if isinstance(cmd, commands.Group):
+                    lines.append(_fmt(cmd.name, "", cmd.description or ""))
                     for sub in sorted(cmd.commands, key=lambda c: c.name):
-                        desc = sub.description or ""
-                        lines.append(f"`{prefix}{cmd.name} {sub.name}` — {desc}")
+                        if sub.hidden:
+                            continue
+                        lines.append(
+                            _fmt(
+                                f"{cmd.name} {sub.name}", sub.signature, sub.description or "", "  "
+                            )
+                        )
                 else:
-                    desc = cmd.description or ""
-                    lines.append(f"`{prefix}{cmd.name}` — {desc}")
+                    lines.append(_fmt(cmd.name, cmd.signature, cmd.description or ""))
             if lines:
-                embed.add_field(name=label, value="\n".join(lines), inline=False)
+                value = "\n".join(lines)
+                if len(value) > 1024:
+                    value = value[:1021] + "..."
+                embed.add_field(name=label, value=value, inline=False)
 
         embed.set_footer(text=f"Prefix: {prefix} • también disponibles como /comando")
         await ctx.send(embed=embed)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -11,9 +11,34 @@ from discord.ext import commands
 from cogs.utility import parse_duration
 
 
+def _log_embed(
+    *,
+    action: str,
+    color: int,
+    mod: discord.Member,
+    target: discord.Member | None = None,
+    reason: str | None = None,
+    extra: str | None = None,
+) -> discord.Embed:
+    embed = discord.Embed(title=f"🔨 {action}", color=color)
+    embed.add_field(name="Moderador", value=mod.mention, inline=True)
+    if target:
+        embed.add_field(name="Usuario", value=f"{target.mention} (`{target}`)", inline=True)
+    if reason:
+        embed.add_field(name="Razón", value=reason, inline=False)
+    if extra:
+        embed.add_field(name="Detalle", value=extra, inline=False)
+    embed.timestamp = discord.utils.utcnow()
+    return embed
+
+
 class Moderation(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+
+    def _log_canal(self) -> discord.TextChannel | None:
+        canal_id = self.bot.config.id_canal_logs
+        return self.bot.get_channel(canal_id) if canal_id else None
 
     @commands.hybrid_command(name="clear", description="Borra N mensajes recientes")
     @commands.has_permissions(manage_messages=True)
@@ -30,6 +55,16 @@ class Moderation(commands.Cog):
             deleted = await ctx.channel.purge(limit=cantidad + 1)
             confirm = await ctx.send(f"🧹 Borrados {len(deleted) - 1} mensajes.")
             await confirm.delete(delay=3)
+        log_ch = self._log_canal()
+        if log_ch:
+            await log_ch.send(
+                embed=_log_embed(
+                    action="Clear",
+                    color=0xF1C40F,
+                    mod=ctx.author,
+                    extra=f"{cantidad} mensajes en {ctx.channel.mention}",
+                )
+            )
 
     @commands.hybrid_command(name="kick", description="Expulsa a un miembro")
     @commands.has_permissions(kick_members=True)
@@ -42,6 +77,13 @@ class Moderation(commands.Cog):
     ):
         await miembro.kick(reason=razon)
         await ctx.send(f"👢 {miembro} expulsado. Razón: {razon or 'no especificada'}")
+        log_ch = self._log_canal()
+        if log_ch:
+            await log_ch.send(
+                embed=_log_embed(
+                    action="Kick", color=0xE67E22, mod=ctx.author, target=miembro, reason=razon
+                )
+            )
 
     @commands.hybrid_command(name="ban", description="Banea a un miembro")
     @commands.has_permissions(ban_members=True)
@@ -54,6 +96,13 @@ class Moderation(commands.Cog):
     ):
         await miembro.ban(reason=razon, delete_message_days=0)
         await ctx.send(f"🔨 {miembro} baneado. Razón: {razon or 'no especificada'}")
+        log_ch = self._log_canal()
+        if log_ch:
+            await log_ch.send(
+                embed=_log_embed(
+                    action="Ban", color=0xE74C3C, mod=ctx.author, target=miembro, reason=razon
+                )
+            )
 
     @commands.hybrid_command(name="timeout", description="Silencia temporalmente")
     @commands.has_permissions(moderate_members=True)
@@ -79,6 +128,18 @@ class Moderation(commands.Cog):
             return
         await miembro.timeout(delta, reason=razon)
         await ctx.send(f"🔇 {miembro} silenciado durante {tiempo}. Razón: {razon or '—'}")
+        log_ch = self._log_canal()
+        if log_ch:
+            await log_ch.send(
+                embed=_log_embed(
+                    action="Timeout",
+                    color=0x9B59B6,
+                    mod=ctx.author,
+                    target=miembro,
+                    reason=razon,
+                    extra=f"Duración: {tiempo}",
+                )
+            )
 
     @commands.hybrid_command(name="say", description="El bot repite tu mensaje")
     @commands.has_permissions(manage_messages=True)

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -632,19 +632,18 @@ class Music(commands.Cog):
             vc = guild.voice_client
             if not vc or not vc.is_connected():
                 continue
-            humanos = [m for m in vc.channel.members if not m.bot]
-            if not humanos:
-                player = self.players.get(guild.id)
-                if player:
-                    player._idle_seconds += 60
-                    if player._idle_seconds >= 120:
-                        await vc.disconnect(force=False)
-                        player.queue.clear()
-                        player.loop_mode = LoopMode.OFF
-                        player._idle_seconds = 0
+            player = self.players.get(guild.id)
+            if not player:
+                continue
+            if vc.is_playing() or vc.is_paused():
+                player._idle_seconds = 0
             else:
-                player = self.players.get(guild.id)
-                if player:
+                player._idle_seconds += 60
+                if player._idle_seconds >= 900:  # 15 min sin reproducir nada
+                    log.info("Desconectando por inactividad en %s", guild.name)
+                    await vc.disconnect(force=False)
+                    player.queue.clear()
+                    player.loop_mode = LoopMode.OFF
                     player._idle_seconds = 0
 
     @idle_check.before_loop

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -398,6 +398,62 @@ class Music(commands.Cog):
 
         await player.start()
 
+    @commands.hybrid_command(
+        name="playnext", description="Inserta una canción como la siguiente en reproducirse"
+    )
+    @app_commands.describe(query="URL o términos de búsqueda")
+    async def playnext(self, ctx: commands.Context, *, query: str):
+        if ctx.author.voice is None or ctx.author.voice.channel is None:
+            await ctx.send("Debes estar en un canal de voz.")
+            return
+
+        if ctx.interaction:
+            await ctx.defer()
+        else:
+            await ctx.message.add_reaction("🔍")
+
+        canal_voz = ctx.author.voice.channel
+        if ctx.voice_client is None:
+            try:
+                await canal_voz.connect(reconnect=False)
+            except discord.errors.ConnectionClosed as e:
+                if ctx.guild.voice_client:
+                    await ctx.guild.voice_client.disconnect(force=True)
+                await ctx.send(
+                    f"No pude unirme al canal (error {e.code}). Espera ~30 s e inténtalo de nuevo."
+                )
+                return
+            except Exception as e:
+                await ctx.send(f"No pude unirme al canal: {e}")
+                return
+        elif ctx.voice_client.channel != canal_voz:
+            await ctx.voice_client.move_to(canal_voz)
+
+        log.info("playnext solicitado por %s: %s", ctx.author, query)
+        info = await self._extract(query)
+        if not ctx.interaction:
+            with contextlib.suppress(discord.HTTPException):
+                await ctx.message.remove_reaction("🔍", ctx.me)
+        if not info:
+            await ctx.send("No pude obtener el audio.")
+            return
+
+        # Siempre tomamos solo un track (primer resultado si es lista/búsqueda)
+        is_url = query.strip().lower().startswith(("http://", "https://"))
+        if not is_url or info.get("entries"):
+            entries = [e for e in (info.get("entries") or []) if e]
+            info = entries[0] if entries else info
+
+        track = _info_to_track(info, str(ctx.author), ctx.channel.id)
+        if not track:
+            await ctx.send("No pude extraer el audio.")
+            return
+
+        player = self.get_player(ctx.guild.id)
+        player.queue.appendleft(track)
+        await ctx.send(embed=_track_embed(track, title="⏭️ Siguiente en la cola", color=0xE67E22))
+        await player.start()
+
     @commands.hybrid_command(name="queue", description="Muestra la cola")
     async def queue_cmd(self, ctx: commands.Context):
         player = self.players.get(ctx.guild.id)

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import logging
 import random
+import time
 from collections import deque
 from dataclasses import dataclass
 from enum import Enum
@@ -128,6 +129,7 @@ class GuildPlayer:
         self._idle_seconds = 0
         self._lock = asyncio.Lock()
         self.autoplay: bool = False
+        self.started_at: float | None = None
 
     async def start(self):
         async with self._lock:
@@ -241,6 +243,7 @@ class GuildPlayer:
 
                 source = discord.FFmpegPCMAudio(url, **FFMPEG_OPTS)
                 source = discord.PCMVolumeTransformer(source, volume=self.volume)
+                self.started_at = time.monotonic()
                 vc.play(source, after=lambda e: self.bot.loop.call_soon_threadsafe(self._next.set))
 
                 channel = self.bot.get_channel(track.text_channel_id)
@@ -595,7 +598,20 @@ class Music(commands.Cog):
         if not player or not player.current:
             await ctx.send("No hay nada reproduciéndose.")
             return
-        await ctx.send(embed=_track_embed(player.current, title="🎧 Sonando ahora", color=0x1DB954))
+        track = player.current
+        embed = _track_embed(track, title="🎧 Sonando ahora", color=0x1DB954)
+        if track.duration and player.started_at is not None:
+            elapsed = int(time.monotonic() - player.started_at)
+            elapsed = min(elapsed, track.duration)
+            pct = elapsed / track.duration
+            filled = int(pct * 15)
+            bar = "▓" * filled + "░" * (15 - filled)
+            embed.add_field(
+                name="Progreso",
+                value=f"`{bar}` {_format_duration(elapsed)} / {_format_duration(track.duration)}",
+                inline=False,
+            )
+        await ctx.send(embed=embed)
 
     @commands.hybrid_command(name="volume", description="Volumen 0-200")
     @app_commands.describe(nivel="Volumen entre 0 y 200")

--- a/cogs/voice.py
+++ b/cogs/voice.py
@@ -1,14 +1,25 @@
-"""Comandos de voz: join, leave, sonidos pregrabados, foto webcam."""
+"""Comandos de voz: join, leave, sonidos pregrabados, foto webcam, tts."""
 
 from __future__ import annotations
 
 import asyncio
+import logging
 import subprocess
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from src.leer_csv import comprobar_whitelist
+
+try:
+    from gtts import gTTS
+
+    _TTS_OK = True
+except ImportError:
+    _TTS_OK = False
+
+log = logging.getLogger("discord.voice")
 
 
 class Voice(commands.Cog):
@@ -104,6 +115,38 @@ class Voice(commands.Cog):
             await canal.send(file=discord.File(result))
             if ctx.channel.id != canal.id:
                 await ctx.send("Foto enviada al canal de bots.", ephemeral=True)
+
+    @commands.hybrid_command(name="tts", description="Reproduce un texto en el canal de voz")
+    @app_commands.describe(texto="Texto a reproducir (máx 200 caracteres)")
+    async def tts(self, ctx: commands.Context, *, texto: str):
+        if not _TTS_OK:
+            await ctx.send("TTS no disponible (instala `gtts`).")
+            return
+        if len(texto) > 200:
+            await ctx.send("Máximo 200 caracteres.")
+            return
+        vc = ctx.guild.voice_client if ctx.guild else None
+        if vc is None:
+            await ctx.send("El bot no está en un canal de voz.")
+            return
+
+        loop = asyncio.get_running_loop()
+        path = f"/tmp/tts_{ctx.guild.id}.mp3"
+
+        def _generate():
+            gTTS(text=texto, lang="es").save(path)
+
+        try:
+            await loop.run_in_executor(None, _generate)
+        except Exception as e:
+            await ctx.send(f"Error generando TTS: {e}")
+            return
+
+        if vc.is_playing():
+            vc.stop()
+        vc.play(discord.FFmpegPCMAudio(path))
+        preview = texto[:60] + ("…" if len(texto) > 60 else "")
+        await ctx.send(f"🔊 *{preview}*")
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/voice.py
+++ b/cogs/voice.py
@@ -1,10 +1,9 @@
-"""Comandos de voz: join, leave, sonidos pregrabados, foto webcam, tts."""
+"""Comandos de voz: join, leave, sonidos pregrabados, tts."""
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import subprocess
 
 import discord
 from discord import app_commands
@@ -73,48 +72,6 @@ class Voice(commands.Cog):
             await ctx.send("🎶 Rickroll iniciado.")
         except Exception as e:
             await ctx.send(f"Error reproduciendo el sonido: {e}")
-
-    @commands.hybrid_command(name="aloe", description="Foto de la cámara aloe")
-    async def aloe(self, ctx: commands.Context):
-        if not comprobar_whitelist(ctx.author.name):
-            await ctx.send("No tienes permiso para usar este comando.")
-            return
-        cam = self.bot.config.cam_device
-        if not cam:
-            await ctx.send("La cámara no está configurada (DISCORD_BOT_CAM).")
-            return
-
-        loop = asyncio.get_running_loop()
-        filename = "/tmp/aloe.jpg"
-
-        def _capture() -> str | None:
-            cmd = [
-                "ffmpeg",
-                "-y",
-                "-f",
-                "v4l2",
-                "-i",
-                cam,
-                "-frames:v",
-                "1",
-                filename,
-            ]
-            try:
-                subprocess.run(cmd, check=True, capture_output=True, timeout=30)
-                return filename
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-                return None
-
-        result = await loop.run_in_executor(None, _capture)
-        if not result:
-            await ctx.send("Error al tomar la foto.")
-            return
-
-        canal = self.bot.get_channel(self.bot.config.id_canal_bots)
-        if canal:
-            await canal.send(file=discord.File(result))
-            if ctx.channel.id != canal.id:
-                await ctx.send("Foto enviada al canal de bots.", ephemeral=True)
 
     @commands.hybrid_command(name="tts", description="Reproduce un texto en el canal de voz")
     @app_commands.describe(texto="Texto a reproducir (máx 200 caracteres)")

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ class KoreaBot(commands.Bot):
             command_prefix=config.prefix,
             intents=intents,
             description="Bot de Korea",
+            help_command=None,
         )
         self.config = config
 

--- a/main.py
+++ b/main.py
@@ -57,14 +57,30 @@ class KoreaBot(commands.Bot):
 
     async def on_ready(self):
         log.info("Conectado como %s (id=%s)", self.user, self.user.id)
-        self.start_time = discord.utils.utcnow()
         await self.change_presence(
             activity=discord.Activity(type=discord.ActivityType.listening, name="/help")
         )
-        canal = self.get_channel(self.config.id_canal_bots)
-        if canal:
+        canal_bots = self.get_channel(self.config.id_canal_bots)
+        if canal_bots:
             with contextlib.suppress(discord.HTTPException):
-                await canal.send(f"✅ Conectado como {self.user} y listo.")
+                await canal_bots.send(f"✅ Conectado como {self.user} y listo.")
+        canal_logs = (
+            self.get_channel(self.config.id_canal_logs) if self.config.id_canal_logs else None
+        )
+        if canal_logs:
+            ts = discord.utils.format_dt(discord.utils.utcnow())
+            with contextlib.suppress(discord.HTTPException):
+                await canal_logs.send(f"🟢 Bot iniciado — {self.user} conectado a Discord {ts}")
+
+    async def on_disconnect(self):
+        log.warning("Bot desconectado de Discord")
+        canal_logs = (
+            self.get_channel(self.config.id_canal_logs) if self.config.id_canal_logs else None
+        )
+        if canal_logs:
+            ts = discord.utils.format_dt(discord.utils.utcnow())
+            with contextlib.suppress(discord.HTTPException):
+                await canal_logs.send(f"🔴 Bot desconectado de Discord {ts}")
 
 
 def _ensure_opus() -> None:

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ class KoreaBot(commands.Bot):
             help_command=None,
         )
         self.config = config
+        self.start_time = discord.utils.utcnow()
 
     async def setup_hook(self) -> None:
         self.heartbeat.start()
@@ -56,6 +57,10 @@ class KoreaBot(commands.Bot):
 
     async def on_ready(self):
         log.info("Conectado como %s (id=%s)", self.user, self.user.id)
+        self.start_time = discord.utils.utcnow()
+        await self.change_presence(
+            activity=discord.Activity(type=discord.ActivityType.listening, name="/help")
+        )
         canal = self.get_channel(self.config.id_canal_bots)
         if canal:
             with contextlib.suppress(discord.HTTPException):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ yt-dlp>=2026.3.17
 PyNaCl>=1.5
 aiohttp>=3.9
 python-dotenv>=1.0
+gTTS>=2.5

--- a/src/config.py
+++ b/src/config.py
@@ -22,6 +22,7 @@ class BotConfig:
     id_canal_principal: int
     id_canal_bots: int
     cam_device: str | None
+    id_canal_logs: int | None
 
     @classmethod
     def load(cls, variables_path: str = "variables.json") -> BotConfig:
@@ -50,10 +51,12 @@ class BotConfig:
                 "DISCORD_ID_CANAL_BOTS o crea variables.json"
             )
 
+        raw_logs = os.getenv("DISCORD_ID_CANAL_LOGS")
         return cls(
             token=token,
             prefix=prefix,
             id_canal_principal=int(id_canal_principal),
             id_canal_bots=int(id_canal_bots),
             cam_device=os.getenv("DISCORD_BOT_CAM"),
+            id_canal_logs=int(raw_logs) if raw_logs else None,
         )

--- a/src/config.py
+++ b/src/config.py
@@ -21,7 +21,6 @@ class BotConfig:
     prefix: str
     id_canal_principal: int
     id_canal_bots: int
-    cam_device: str | None
     id_canal_logs: int | None
 
     @classmethod
@@ -57,6 +56,5 @@ class BotConfig:
             prefix=prefix,
             id_canal_principal=int(id_canal_principal),
             id_canal_bots=int(id_canal_bots),
-            cam_device=os.getenv("DISCORD_BOT_CAM"),
             id_canal_logs=int(raw_logs) if raw_logs else None,
         )

--- a/src/info.py
+++ b/src/info.py
@@ -15,10 +15,5 @@ def definir_info():
         "Algunas funciones tienen whitelist.",
         inline=False,
     )
-    embed.add_field(
-        name="Comandos",
-        value="Usa `<help_korea` o `/help_korea` para ver la lista por categorías.",
-        inline=False,
-    )
     embed.set_footer(text="Usa el bot con responsabilidad")
     return embed

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -176,7 +176,7 @@ async def bot():
         prefix="<",
         id_canal_principal=1,
         id_canal_bots=2,
-        cam_device=None,
+        id_canal_logs=None,
     )
     b = _BotForTest(config)
     await b._async_setup_hook()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -27,7 +27,7 @@ from src.config import BotConfig
 class _BotForTest(commands.Bot):
     def __init__(self, config: BotConfig):
         intents = discord.Intents.all()
-        super().__init__(command_prefix=config.prefix, intents=intents)
+        super().__init__(command_prefix=config.prefix, intents=intents, help_command=None)
         self.config = config
 
     async def setup_hook(self) -> None:

--- a/tests/e2e/test_general_e2e.py
+++ b/tests/e2e/test_general_e2e.py
@@ -21,8 +21,4 @@ async def test_info_envia_embed(harness):
     assert "Bot de Korea" in result.embeds[0].title
 
 
-async def test_help_korea_lista_categorias(harness):
-    result = await harness.invoke("help_korea")
-    assert result.embeds
-    field_names = {f.name for f in result.embeds[0].fields}
-    assert {"General", "Música", "Juegos", "Moderación"} <= field_names
+

--- a/tests/e2e/test_general_e2e.py
+++ b/tests/e2e/test_general_e2e.py
@@ -19,6 +19,3 @@ async def test_info_envia_embed(harness):
     result = await harness.invoke("info")
     assert result.embeds, "info debería responder con un embed"
     assert "Bot de Korea" in result.embeds[0].title
-
-
-

--- a/tests/test_birthdays.py
+++ b/tests/test_birthdays.py
@@ -1,0 +1,48 @@
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+import cogs.birthdays as bd_module
+from cogs.birthdays import _load, _save
+
+
+@pytest.fixture()
+def tmp_birthday_file(tmp_path):
+    f = tmp_path / "birthdays.json"
+    with patch.object(bd_module, "BIRTHDAY_FILE", f):
+        yield f
+
+
+def test_load_returns_empty_if_missing(tmp_birthday_file):
+    assert _load() == {}
+
+
+def test_save_and_load_roundtrip(tmp_birthday_file):
+    data = {"123": {"456": "12-25"}}
+    with patch.object(bd_module, "BIRTHDAY_FILE", tmp_birthday_file):
+        _save(data)
+        assert _load() == data
+
+
+def test_load_handles_corrupt_file(tmp_birthday_file):
+    tmp_birthday_file.write_text("NOT JSON", encoding="utf-8")
+    with patch.object(bd_module, "BIRTHDAY_FILE", tmp_birthday_file):
+        assert _load() == {}
+
+
+@pytest.mark.parametrize(
+    "mmdd, today, expected_days",
+    [
+        ("12-25", date(2026, 12, 25), 0),
+        ("12-25", date(2026, 12, 24), 1),
+        ("01-01", date(2026, 12, 31), 1),  # año nuevo
+        ("06-15", date(2026, 6, 14), 1),
+    ],
+)
+def test_days_until_birthday(mmdd, today, expected_days):
+    month, day = int(mmdd[:2]), int(mmdd[3:])
+    bd = date(today.year, month, day)
+    if bd < today:
+        bd = date(today.year + 1, month, day)
+    assert (bd - today).days == expected_days

--- a/tests/test_birthdays.py
+++ b/tests/test_birthdays.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 import cogs.birthdays as bd_module
-from cogs.birthdays import _load, _save
+from cogs.birthdays import _load, _next_occurrence, _save
 
 
 @pytest.fixture()
@@ -42,7 +42,19 @@ def test_load_handles_corrupt_file(tmp_birthday_file):
 )
 def test_days_until_birthday(mmdd, today, expected_days):
     month, day = int(mmdd[:2]), int(mmdd[3:])
-    bd = date(today.year, month, day)
-    if bd < today:
-        bd = date(today.year + 1, month, day)
+    bd = _next_occurrence(month, day, today)
     assert (bd - today).days == expected_days
+
+
+@pytest.mark.parametrize(
+    "month, day, today, expected_year",
+    [
+        (2, 29, date(2025, 3, 1), 2028),  # año no bisiesto, ya pasó → 2028
+        (2, 29, date(2028, 2, 29), 2028),  # hoy mismo en año bisiesto → 2028
+        (2, 29, date(2028, 3, 1), 2032),  # año bisiesto pero ya pasó → 2032
+        (2, 29, date(2025, 1, 1), 2028),  # año no bisiesto, aún no ha pasado → 2028
+    ],
+)
+def test_next_occurrence_leap_day(month, day, today, expected_year):
+    bd = _next_occurrence(month, day, today)
+    assert bd == date(expected_year, 2, 29)


### PR DESCRIPTION
## Resumen

- **Presencia**: el bot aparece como *Escuchando /help* al conectarse
- **`/stats`**: uptime, servidores, usuarios, latencia, versiones de discord.py y Python
- **`/invite`**: genera URL OAuth2 con los permisos necesarios
- **`/docs`**: embed con resumen de categorías de comandos y link al repo
- **`/nowplaying` mejorado**: muestra barra de progreso `▓▓▓░░░░ 1:23 / 3:45` cuando hay duración disponible
- **README**: reescrito con badges de CI, tabla de características, menos documentación inline

> Depende de #41 (o aplica sobre main una vez mergeada)

## Test plan

- [ ] CI pasa (ruff + pytest + docker build)
- [ ] `/stats` muestra uptime, servidores y versiones correctas
- [ ] `/invite` genera un link de OAuth2 válido
- [ ] `/docs` muestra el embed con categorías y link a GitHub
- [ ] `/nowplaying` muestra barra de progreso durante reproducción
- [ ] El bot aparece como "Escuchando /help" en la lista de miembros