### PR TITLE
fix: persistencia de datos + auto-release workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ DISCORD_ID_CANAL_BOTS=
 
 # Canal de logs de moderación (opcional — kick, ban, timeout, clear)
 DISCORD_ID_CANAL_LOGS=
+
+# Directorio donde se guardan whitelist.json y birthdays.json
+# En producción apunta a un volumen persistente (ej. /app/data)
+BOT_DATA_DIR=

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,76 @@
+name: auto-release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determinar tipo de bump
+        id: bump
+        run: |
+          labels='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          if echo "$labels" | jq -e '.[] | select(. == "major")' > /dev/null 2>&1; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif echo "$labels" | jq -e '.[] | select(. == "minor")' > /dev/null 2>&1; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          elif echo "$labels" | jq -e '.[] | select(. == "patch")' > /dev/null 2>&1; then
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=none" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Obtener último tag semver
+        if: steps.bump.outputs.type != 'none'
+        id: tag
+        run: |
+          latest=$(git tag --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          echo "latest=${latest:-0.0.0}" >> "$GITHUB_OUTPUT"
+
+      - name: Calcular nueva versión
+        if: steps.bump.outputs.type != 'none'
+        id: version
+        run: |
+          IFS='.' read -r major minor patch <<< "${{ steps.tag.outputs.latest }}"
+          case "${{ steps.bump.outputs.type }}" in
+            major) new="$((major + 1)).0.0" ;;
+            minor) new="${major}.$((minor + 1)).0" ;;
+            patch) new="${major}.${minor}.$((patch + 1))" ;;
+          esac
+          echo "new=$new" >> "$GITHUB_OUTPUT"
+
+      - name: Crear release
+        if: steps.bump.outputs.type != 'none'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.new }}" \
+            --title "${{ steps.version.outputs.new }}" \
+            --generate-notes \
+            --repo "${{ github.repository }}"
+
+      - name: Resumen
+        if: always()
+        run: |
+          {
+            echo "### 🏷️ Auto-release"
+            if [ "${{ steps.bump.outputs.type }}" = "none" ]; then
+              echo "Sin label \`major\`, \`minor\` o \`patch\` — no se creó release."
+            else
+              echo "- Bump: **${{ steps.bump.outputs.type }}**"
+              echo "- Anterior: \`${{ steps.tag.outputs.latest }}\`"
+              echo "- Nueva: \`${{ steps.version.outputs.new }}\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/cogs/birthdays.py
+++ b/cogs/birthdays.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from datetime import date
 from pathlib import Path
 
@@ -13,7 +14,8 @@ from discord.ext import commands, tasks
 
 log = logging.getLogger("discord.birthdays")
 
-BIRTHDAY_FILE = Path("birthdays.json")
+_DATA_DIR = Path(os.getenv("BOT_DATA_DIR", "."))
+BIRTHDAY_FILE = _DATA_DIR / "birthdays.json"
 
 
 def _load() -> dict:

--- a/src/whitelist.py
+++ b/src/whitelist.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 
 log = logging.getLogger(__name__)
 
-_WHITELIST_FILE = Path(__file__).parent.parent / "whitelist.json"
+_DATA_DIR = Path(os.getenv("BOT_DATA_DIR", str(Path(__file__).parent.parent)))
+_WHITELIST_FILE = _DATA_DIR / "whitelist.json"
 
 
 def _load() -> list[int]:


### PR DESCRIPTION
## Resumen

- **Fix persistencia**: `whitelist.json` y `birthdays.json` se perdían al reiniciar el contenedor porque se escribían dentro del filesystem del contenedor. Se introduce `BOT_DATA_DIR` (env var) que apunta a un volumen externo en producción.
- **Auto-release**: nuevo workflow que crea release automáticamente al mergear una PR en `main` según la label (`major` / `minor` / `patch`). Sin label → no se crea release.

## Cambios en infra

El docker-compose del server ya tiene el volumen y la variable:
```yaml
volumes:
  - /home/enriqueav/discord-bot-data:/app/data
environment:
  BOT_DATA_DIR: /app/data
```

⚠️ Antes de reiniciar el contenedor hay que crear el directorio en el servidor:
```bash
mkdir -p /home/enriqueav/discord-bot-data
```

## Test plan

- [ ] CI pasa
- [ ] Al reiniciar el bot, `whitelist.json` y `birthdays.json` persisten
- [ ] PR con label `patch` mergeada → release x.y.Z+1 creado automáticamente
- [ ] PR sin label de release → no se crea release