### PR TITLE
fix(ci): usa PAT en auto-release para disparar docker-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Crear release
         if: steps.bump.outputs.type != 'none'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SERVER_REPO_PAT }}
         run: |
           gh release create "${{ steps.version.outputs.new }}" \
             --title "${{ steps.version.outputs.new }}" \


### PR DESCRIPTION
## Summary
- GitHub bloquea que workflows creados con `GITHUB_TOKEN` disparen otros workflows (medida anti-loop)
- `auto-release` creaba la release con `GITHUB_TOKEN`, por eso `docker-release` nunca saltaba al evento `release: published`
- Cambiado a `SERVER_REPO_PAT` (PAT de usuario), que sí puede disparar workflows

## Test plan
- [ ] Mergear una PR con label `patch` y comprobar que `auto-release` crea la release y `docker-release` arranca automáticamente