### PR TITLE
fix: notificar reconexión del bot en canal de logs

### DIFF
--- a/main.py
+++ b/main.py
@@ -102,6 +102,16 @@ class KoreaBot(commands.Bot):
             with contextlib.suppress(discord.HTTPException):
                 await canal_logs.send(f"🔴 Bot desconectado de Discord {ts}")
 
+    async def on_resumed(self):
+        log.info("Sesión de Discord retomada")
+        canal_logs = (
+            self.get_channel(self.config.id_canal_logs) if self.config.id_canal_logs else None
+        )
+        if canal_logs:
+            ts = discord.utils.format_dt(discord.utils.utcnow())
+            with contextlib.suppress(discord.HTTPException):
+                await canal_logs.send(f"🟡 Bot reconectado (sesión retomada) {ts}")
+
 
 def _ensure_opus() -> None:
     if discord.opus.is_loaded():


### PR DESCRIPTION
## Problema

El canal de moderación mostraba el mensaje 🔴 de desconexión pero nunca el mensaje de reconexión. El bot se desconectaba y reconectaba sin avisar.

## Causa

discord.py reconecta automáticamente mediante *resume* de sesión, que dispara `on_resumed` — no `on_ready`. Como `on_resumed` no estaba implementado, el mensaje de reconexión nunca se enviaba.

## Fix

Añade `on_resumed` que manda 🟡 al canal de logs con la hora de reconexión.