### PR TITLE
feat(moderation): warns, automod configurable y logging extendido

### DIFF
--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -10,6 +10,7 @@ EXTENSIONS = (
     "cogs.birthdays",
     "cogs.voice",
     "cogs.moderation",
+    "cogs.automod",
     "cogs.utility",
     "cogs.events",
 )

--- a/cogs/automod.py
+++ b/cogs/automod.py
@@ -1,0 +1,189 @@
+"""Automoderación configurable por servidor."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+from pathlib import Path
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+log = logging.getLogger("discord.automod")
+
+_DATA_DIR = Path(os.getenv("BOT_DATA_DIR", "."))
+_AUTOMOD_FILE = _DATA_DIR / "automod.json"
+
+
+def _load() -> dict:
+    if _AUTOMOD_FILE.exists():
+        try:
+            return json.loads(_AUTOMOD_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            log.warning("No se pudo leer %s", _AUTOMOD_FILE)
+    return {}
+
+
+def _save(data: dict) -> None:
+    try:
+        _AUTOMOD_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except Exception:
+        log.error("No se pudo guardar automod.json", exc_info=True)
+
+
+class Automod(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self._config: dict = _load()
+
+    def _guild_cfg(self, guild_id: int) -> dict:
+        return self._config.setdefault(str(guild_id), {"words": [], "max_mentions": 0})
+
+    def _log_canal(self) -> discord.TextChannel | None:
+        canal_id = self.bot.config.id_canal_logs
+        return self.bot.get_channel(canal_id) if canal_id else None
+
+    # ── listener ─────────────────────────────────────────────────────────────
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if message.author.bot or not message.guild:
+            return
+
+        cfg = self._guild_cfg(message.guild.id)
+        reason = None
+
+        content_lower = message.content.lower()
+        for word in cfg.get("words", []):
+            if word.lower() in content_lower:
+                reason = f"palabra prohibida: `{word}`"
+                break
+
+        if reason is None:
+            max_mentions = cfg.get("max_mentions", 0)
+            if max_mentions > 0:
+                unique = len({m.id for m in message.mentions if not m.bot})
+                if unique > max_mentions:
+                    reason = f"demasiadas menciones ({unique} > {max_mentions})"
+
+        if reason is None:
+            return
+
+        with contextlib.suppress(discord.HTTPException):
+            await message.delete()
+
+        with contextlib.suppress(discord.HTTPException):
+            notif = await message.channel.send(
+                f"🚫 {message.author.mention} mensaje eliminado por automod ({reason})."
+            )
+            await notif.delete(delay=5)
+
+        log_ch = self._log_canal()
+        if log_ch:
+            embed = discord.Embed(title="🤖 Automod — mensaje eliminado", color=0xE74C3C)
+            embed.add_field(
+                name="Usuario",
+                value=f"{message.author.mention} (`{message.author}`)",
+                inline=True,
+            )
+            embed.add_field(name="Canal", value=message.channel.mention, inline=True)
+            embed.add_field(name="Razón", value=reason, inline=False)
+            if message.content:
+                embed.add_field(name="Contenido", value=message.content[:500], inline=False)
+            embed.timestamp = discord.utils.utcnow()
+            with contextlib.suppress(discord.HTTPException):
+                await log_ch.send(embed=embed)
+
+    # ── /automod ─────────────────────────────────────────────────────────────
+
+    @commands.hybrid_group(name="automod", description="Configura el automoderador 🤖")
+    @commands.has_permissions(manage_guild=True)
+    @commands.guild_only()
+    async def automod_cmd(self, ctx: commands.Context):
+        if ctx.invoked_subcommand is None:
+            cfg = self._guild_cfg(ctx.guild.id)
+            words = cfg.get("words", [])
+            max_m = cfg.get("max_mentions", 0)
+            embed = discord.Embed(title="🤖 Configuración Automod", color=0x3498DB)
+            embed.add_field(
+                name="Palabras prohibidas",
+                value=", ".join(f"`{w}`" for w in words) or "ninguna",
+                inline=False,
+            )
+            embed.add_field(
+                name="Máx. menciones",
+                value=str(max_m) if max_m > 0 else "desactivado",
+                inline=True,
+            )
+            await ctx.send(embed=embed, ephemeral=True)
+
+    @automod_cmd.command(name="add", description="Añade una palabra a la lista negra")
+    @app_commands.describe(palabra="Palabra o frase a prohibir")
+    async def automod_add(self, ctx: commands.Context, *, palabra: str):
+        cfg = self._guild_cfg(ctx.guild.id)
+        word = palabra.lower().strip()
+        if word in cfg["words"]:
+            await ctx.send(f"`{word}` ya está en la lista.", ephemeral=True)
+            return
+        cfg["words"].append(word)
+        _save(self._config)
+        await ctx.send(f"✅ `{word}` añadida a la lista negra.", ephemeral=True)
+
+    @automod_cmd.command(name="remove", description="Elimina una palabra de la lista negra")
+    @app_commands.describe(palabra="Palabra a eliminar")
+    async def automod_remove(self, ctx: commands.Context, *, palabra: str):
+        cfg = self._guild_cfg(ctx.guild.id)
+        word = palabra.lower().strip()
+        if word not in cfg["words"]:
+            await ctx.send(f"`{word}` no está en la lista.", ephemeral=True)
+            return
+        cfg["words"].remove(word)
+        _save(self._config)
+        await ctx.send(f"🗑️ `{word}` eliminada de la lista negra.", ephemeral=True)
+
+    @automod_cmd.command(name="list", description="Muestra la configuración del automod")
+    async def automod_list(self, ctx: commands.Context):
+        cfg = self._guild_cfg(ctx.guild.id)
+        words = cfg.get("words", [])
+        max_m = cfg.get("max_mentions", 0)
+        embed = discord.Embed(title="🤖 Automod", color=0x3498DB)
+        embed.add_field(
+            name="Palabras prohibidas",
+            value="\n".join(f"• `{w}`" for w in words) or "ninguna",
+            inline=False,
+        )
+        embed.add_field(
+            name="Máx. menciones",
+            value=str(max_m) if max_m > 0 else "desactivado",
+            inline=True,
+        )
+        await ctx.send(embed=embed, ephemeral=True)
+
+    @automod_cmd.command(
+        name="menciones",
+        description="Máximo de menciones por mensaje (0 = desactivado)",
+    )
+    @app_commands.describe(maximo="Número máximo permitido (0 = off)")
+    async def automod_menciones(self, ctx: commands.Context, maximo: int):
+        if maximo < 0:
+            await ctx.send("El valor mínimo es 0 (desactivado).", ephemeral=True)
+            return
+        cfg = self._guild_cfg(ctx.guild.id)
+        cfg["max_mentions"] = maximo
+        _save(self._config)
+        if maximo == 0:
+            await ctx.send("🔕 Límite de menciones desactivado.", ephemeral=True)
+        else:
+            await ctx.send(f"✅ Máximo de menciones por mensaje: **{maximo}**.", ephemeral=True)
+
+    @automod_cmd.error
+    async def automod_error(self, ctx: commands.Context, error: Exception):
+        if isinstance(error, commands.MissingPermissions):
+            await ctx.send("Necesitas el permiso `Gestionar servidor`.", ephemeral=True)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(Automod(bot))

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -1,7 +1,8 @@
-"""Eventos del servidor: bienvenidas, despedidas, error handler global."""
+"""Eventos del servidor: bienvenidas, despedidas, logging extendido, error handler."""
 
 from __future__ import annotations
 
+import contextlib
 import logging
 
 import discord
@@ -13,6 +14,10 @@ log = logging.getLogger("discord.events")
 class Events(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+
+    def _log_canal(self) -> discord.TextChannel | None:
+        canal_id = self.bot.config.id_canal_logs
+        return self.bot.get_channel(canal_id) if canal_id else None
 
     @commands.Cog.listener()
     async def on_member_join(self, member: discord.Member):
@@ -34,6 +39,139 @@ class Events(commands.Cog):
         canal = self.bot.get_channel(self.bot.config.id_canal_principal)
         if canal:
             await canal.send(f"**{member}** ha abandonado el servidor.")
+
+    # ── logging extendido ────────────────────────────────────────────────────
+
+    @commands.Cog.listener()
+    async def on_message_edit(self, before: discord.Message, after: discord.Message):
+        if before.author.bot or not before.guild or before.content == after.content:
+            return
+        log_ch = self._log_canal()
+        if not log_ch:
+            return
+        embed = discord.Embed(title="✏️ Mensaje editado", color=0x3498DB, url=after.jump_url)
+        embed.add_field(
+            name="Usuario", value=f"{before.author.mention} (`{before.author}`)", inline=True
+        )
+        embed.add_field(name="Canal", value=before.channel.mention, inline=True)
+        embed.add_field(name="Antes", value=before.content[:500] or "*(vacío)*", inline=False)
+        embed.add_field(name="Después", value=after.content[:500] or "*(vacío)*", inline=False)
+        embed.timestamp = discord.utils.utcnow()
+        with contextlib.suppress(discord.HTTPException):
+            await log_ch.send(embed=embed)
+
+    @commands.Cog.listener()
+    async def on_message_delete(self, message: discord.Message):
+        if message.author.bot or not message.guild:
+            return
+        log_ch = self._log_canal()
+        if not log_ch:
+            return
+        embed = discord.Embed(title="🗑️ Mensaje eliminado", color=0xE74C3C)
+        embed.add_field(
+            name="Usuario", value=f"{message.author.mention} (`{message.author}`)", inline=True
+        )
+        embed.add_field(name="Canal", value=message.channel.mention, inline=True)
+        if message.content:
+            embed.add_field(name="Contenido", value=message.content[:500], inline=False)
+        embed.timestamp = discord.utils.utcnow()
+        with contextlib.suppress(discord.HTTPException):
+            await log_ch.send(embed=embed)
+
+    @commands.Cog.listener()
+    async def on_member_update(self, before: discord.Member, after: discord.Member):
+        log_ch = self._log_canal()
+        if not log_ch:
+            return
+        if before.nick != after.nick:
+            embed = discord.Embed(title="✏️ Cambio de nick", color=0x9B59B6)
+            embed.add_field(name="Usuario", value=f"{after.mention} (`{after}`)", inline=False)
+            embed.add_field(name="Antes", value=before.nick or before.name, inline=True)
+            embed.add_field(name="Después", value=after.nick or after.name, inline=True)
+            embed.timestamp = discord.utils.utcnow()
+            with contextlib.suppress(discord.HTTPException):
+                await log_ch.send(embed=embed)
+        added = [r for r in after.roles if r not in before.roles and not r.is_default()]
+        removed = [r for r in before.roles if r not in after.roles and not r.is_default()]
+        if added or removed:
+            embed = discord.Embed(title="🎭 Cambio de roles", color=0x1ABC9C)
+            embed.add_field(name="Usuario", value=f"{after.mention} (`{after}`)", inline=False)
+            if added:
+                embed.add_field(
+                    name="Añadidos", value=" ".join(r.mention for r in added), inline=True
+                )
+            if removed:
+                embed.add_field(
+                    name="Eliminados", value=" ".join(r.mention for r in removed), inline=True
+                )
+            embed.timestamp = discord.utils.utcnow()
+            with contextlib.suppress(discord.HTTPException):
+                await log_ch.send(embed=embed)
+
+    @commands.Cog.listener()
+    async def on_guild_channel_create(self, channel: discord.abc.GuildChannel):
+        log_ch = self._log_canal()
+        if not log_ch:
+            return
+        embed = discord.Embed(title="➕ Canal creado", color=0x2ECC71)
+        embed.add_field(name="Canal", value=f"{channel.mention} (`{channel.name}`)", inline=True)
+        embed.add_field(name="Tipo", value=str(channel.type).replace("_", " ").title(), inline=True)
+        if hasattr(channel, "category") and channel.category:
+            embed.add_field(name="Categoría", value=channel.category.name, inline=True)
+        embed.timestamp = discord.utils.utcnow()
+        with contextlib.suppress(discord.HTTPException):
+            await log_ch.send(embed=embed)
+
+    @commands.Cog.listener()
+    async def on_guild_channel_delete(self, channel: discord.abc.GuildChannel):
+        log_ch = self._log_canal()
+        if not log_ch:
+            return
+        embed = discord.Embed(title="➖ Canal eliminado", color=0xE74C3C)
+        embed.add_field(name="Canal", value=f"`{channel.name}`", inline=True)
+        embed.add_field(name="Tipo", value=str(channel.type).replace("_", " ").title(), inline=True)
+        if hasattr(channel, "category") and channel.category:
+            embed.add_field(name="Categoría", value=channel.category.name, inline=True)
+        embed.timestamp = discord.utils.utcnow()
+        with contextlib.suppress(discord.HTTPException):
+            await log_ch.send(embed=embed)
+
+    @commands.Cog.listener()
+    async def on_invite_create(self, invite: discord.Invite):
+        log_ch = self._log_canal()
+        if not log_ch:
+            return
+        embed = discord.Embed(title="🔗 Invitación creada", color=0x3498DB)
+        embed.add_field(name="Código", value=f"`{invite.code}`", inline=True)
+        embed.add_field(
+            name="Creador",
+            value=invite.inviter.mention if invite.inviter else "desconocido",
+            inline=True,
+        )
+        embed.add_field(
+            name="Usos máx.", value=str(invite.max_uses) if invite.max_uses else "∞", inline=True
+        )
+        embed.add_field(
+            name="Expira",
+            value=str(invite.expires_at)[:10] if invite.expires_at else "nunca",
+            inline=True,
+        )
+        embed.timestamp = discord.utils.utcnow()
+        with contextlib.suppress(discord.HTTPException):
+            await log_ch.send(embed=embed)
+
+    @commands.Cog.listener()
+    async def on_invite_delete(self, invite: discord.Invite):
+        log_ch = self._log_canal()
+        if not log_ch:
+            return
+        embed = discord.Embed(title="🔗 Invitación eliminada", color=0xE74C3C)
+        embed.add_field(name="Código", value=f"`{invite.code}`", inline=True)
+        embed.timestamp = discord.utils.utcnow()
+        with contextlib.suppress(discord.HTTPException):
+            await log_ch.send(embed=embed)
+
+    # ── error handler ────────────────────────────────────────────────────────
 
     @commands.Cog.listener()
     async def on_command_error(self, ctx: commands.Context, error: Exception):

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -24,6 +24,7 @@ _COGS = [
     ("Casino", "🎰", "Casino"),
     ("Utility", "🛠️", "Utilidad"),
     ("Moderation", "🔨", "Moderación"),
+    ("Automod", "🤖", "Automod"),
 ]
 _COG_EMOJI = {name: emoji for name, emoji, _ in _COGS}
 _COG_LABEL = {name: label for name, _, label in _COGS}

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -2,13 +2,38 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+import json
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 
 from cogs.utility import parse_duration
+
+log = logging.getLogger("discord.moderation")
+
+_DATA_DIR = Path(os.getenv("BOT_DATA_DIR", "."))
+_WARNS_FILE = _DATA_DIR / "warns.json"
+
+
+def _load_warns() -> dict:
+    if _WARNS_FILE.exists():
+        try:
+            return json.loads(_WARNS_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            log.warning("No se pudo leer %s", _WARNS_FILE)
+    return {}
+
+
+def _save_warns(data: dict) -> None:
+    try:
+        _WARNS_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except Exception:
+        log.error("No se pudo guardar warns.json", exc_info=True)
 
 
 def _log_embed(
@@ -35,6 +60,7 @@ def _log_embed(
 class Moderation(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self._warns: dict = _load_warns()
 
     def _log_canal(self) -> discord.TextChannel | None:
         canal_id = self.bot.config.id_canal_logs
@@ -151,11 +177,104 @@ class Moderation(commands.Cog):
             await ctx.message.delete()
             await ctx.channel.send(texto)
 
+    # ── /warn ────────────────────────────────────────────────────────────────
+
+    @commands.hybrid_command(name="warn", description="Advierte a un miembro ⚠️")
+    @commands.has_permissions(manage_messages=True)
+    @commands.guild_only()
+    @app_commands.describe(miembro="Miembro a advertir", razon="Motivo de la advertencia")
+    async def warn(
+        self,
+        ctx: commands.Context,
+        miembro: discord.Member,
+        *,
+        razon: str | None = None,
+    ):
+        if miembro.bot:
+            await ctx.send("No se puede advertir a un bot.", ephemeral=True)
+            return
+        gk, uk = str(ctx.guild.id), str(miembro.id)
+        entry = {
+            "reason": razon or "sin razón",
+            "mod_id": ctx.author.id,
+            "timestamp": datetime.now(UTC).isoformat(),
+        }
+        self._warns.setdefault(gk, {}).setdefault(uk, []).append(entry)
+        _save_warns(self._warns)
+        count = len(self._warns[gk][uk])
+        await ctx.send(
+            f"⚠️ {miembro.mention} advertido. Total: **{count}** warn(s). Razón: {razon or '—'}"
+        )
+        log_ch = self._log_canal()
+        if log_ch:
+            await log_ch.send(
+                embed=_log_embed(
+                    action=f"Warn #{count}",
+                    color=0xF39C12,
+                    mod=ctx.author,
+                    target=miembro,
+                    reason=razon,
+                )
+            )
+
+    # ── /infractions ─────────────────────────────────────────────────────────
+
+    @commands.hybrid_command(name="infractions", description="Historial de warns de un miembro")
+    @commands.has_permissions(manage_messages=True)
+    @commands.guild_only()
+    async def infractions(self, ctx: commands.Context, miembro: discord.Member):
+        gk, uk = str(ctx.guild.id), str(miembro.id)
+        warns = self._warns.get(gk, {}).get(uk, [])
+        if not warns:
+            await ctx.send(f"{miembro.mention} no tiene advertencias.", ephemeral=True)
+            return
+        embed = discord.Embed(
+            title=f"⚠️ Infracciones de {miembro.display_name}",
+            color=0xF39C12,
+        )
+        for i, w in enumerate(warns, 1):
+            mod = ctx.guild.get_member(w["mod_id"])
+            mod_name = mod.display_name if mod else f"<mod {w['mod_id']}>"
+            ts = w["timestamp"][:10]
+            embed.add_field(
+                name=f"#{i} — {ts}",
+                value=f"**Razón:** {w['reason']}\n**Mod:** {mod_name}",
+                inline=False,
+            )
+        await ctx.send(embed=embed, ephemeral=True)
+
+    # ── /clearwarns ──────────────────────────────────────────────────────────
+
+    @commands.hybrid_command(name="clearwarns", description="Limpia todos los warns de un miembro")
+    @commands.has_permissions(manage_guild=True)
+    @commands.guild_only()
+    async def clearwarns(self, ctx: commands.Context, miembro: discord.Member):
+        gk, uk = str(ctx.guild.id), str(miembro.id)
+        if not self._warns.get(gk, {}).get(uk):
+            await ctx.send(f"{miembro.mention} no tiene advertencias.", ephemeral=True)
+            return
+        self._warns[gk].pop(uk, None)
+        _save_warns(self._warns)
+        await ctx.send(f"✅ Warns de {miembro.mention} eliminados.")
+        log_ch = self._log_canal()
+        if log_ch:
+            await log_ch.send(
+                embed=_log_embed(
+                    action="Clear warns",
+                    color=0x2ECC71,
+                    mod=ctx.author,
+                    target=miembro,
+                )
+            )
+
     @kick.error
     @ban.error
     @timeout.error
     @clear.error
     @say.error
+    @warn.error
+    @infractions.error
+    @clearwarns.error
     async def perm_error(self, ctx: commands.Context, error: Exception):
         if isinstance(error, commands.MissingPermissions):
             await ctx.send("No tienes permisos para usar este comando.", ephemeral=True)


### PR DESCRIPTION
## Moderación

### Sistema de warns
- `/warn @usuario [razón]` — advierte a un miembro, guarda en `warns.json`
- `/infractions @usuario` — lista el historial completo con fecha y moderador
- `/clearwarns @usuario` — limpia todos los warns (requiere Gestionar servidor)
- Cada acción se registra en el canal de logs

### Automod configurable
- `/automod add <palabra>` — añade a la lista negra
- `/automod remove <palabra>` — elimina de la lista negra
- `/automod list` — muestra la configuración actual
- `/automod menciones <N>` — máximo de menciones por mensaje (0 = off)
- Al detectar infracción: borra el mensaje, avisa al usuario en el canal (auto-delete 5s) y registra en logs
- Config guardada en `automod.json` por servidor

### Logging extendido
Todos los eventos van al canal `DISCORD_ID_CANAL_LOGS`:
- ✏️ Mensaje editado (antes/después)
- 🗑️ Mensaje eliminado
- ✏️ Cambio de nick
- 🎭 Cambio de roles (añadidos/eliminados)
- ➕➖ Canal creado/eliminado
- 🔗 Invitación creada/eliminada

## Test plan
- [ ] `/warn @user motivo` — aparece en logs, cuenta acumulada correcta
- [ ] `/infractions @user` — lista todos los warns con fecha y mod
- [ ] `/clearwarns @user` — limpia, aparece en logs
- [ ] `/automod add palabrota` → enviar mensaje con esa palabra → borrado + log
- [ ] `/automod menciones 3` → mencionar 4 usuarios → borrado + log
- [ ] Editar un mensaje → aparece en logs con antes/después
- [ ] Crear un canal → aparece en logs