### PR TITLE
feat(economia): /trabajo, /heist, /unirse y /tienda

### DIFF
--- a/cogs/casino.py
+++ b/cogs/casino.py
@@ -9,11 +9,12 @@ import logging
 import os
 import random
 import re
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import discord
 from discord import app_commands
-from discord.ext import commands
+from discord.ext import commands, tasks
 
 log = logging.getLogger("discord.casino")
 
@@ -26,6 +27,29 @@ _APUESTA_DEFAULT = 100
 _RECARGA = 500
 _COOLDOWN_RECARGA_H = 6
 _MAX_APUESTAS = 8
+
+_SHOP_FILE = _DATA_DIR / "tienda.json"
+_HEIST_DURACION = 60
+
+_TRABAJOS = [
+    ("minero", 60, 140),
+    ("carpintero", 50, 120),
+    ("pescador", 40, 100),
+    ("cocinero", 70, 130),
+    ("guardia", 80, 160),
+    ("mercader", 90, 200),
+    ("herrero", 75, 150),
+    ("escriba", 55, 110),
+    ("alquimista", 100, 250),
+    ("bufón", 10, 400),
+]
+_TRABAJO_MSGS = [
+    "Trabajaste como {trabajo} y ganaste **{fichas}** 🪙.",
+    "Un día duro de {trabajo}. Cobras **{fichas}** 🪙.",
+    "Tu jefe quedó satisfecho. **{fichas}** 🪙 como {trabajo}.",
+    "Otro día, otra moneda. **{fichas}** 🪙 por ser {trabajo}.",
+    "Jornada completa como {trabajo}. Sueldo: **{fichas}** 🪙.",
+]
 
 # Tragaperras — símbolos ordenados de más a menos frecuente
 _SLOTS = ["🍒", "🍒", "🍒", "🍋", "🍋", "🍊", "🍊", "🍇", "🔔", "💎", "7️⃣"]
@@ -87,6 +111,22 @@ def _save(data: dict[str, dict[str, int]]) -> None:
         _FICHAS_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
     except Exception:
         log.error("No se pudo guardar fichas.json", exc_info=True)
+
+
+def _load_shop() -> dict:
+    if _SHOP_FILE.exists():
+        try:
+            return json.loads(_SHOP_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            log.warning("No se pudo leer %s, empezando vacío", _SHOP_FILE)
+    return {}
+
+
+def _save_shop(data: dict) -> None:
+    try:
+        _SHOP_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except Exception:
+        log.error("No se pudo guardar tienda.json", exc_info=True)
 
 
 def _color_emoji(n: int) -> str:
@@ -317,6 +357,65 @@ class Casino(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._fichas: dict[str, dict[str, int]] = _load()
+        self._shop: dict = _load_shop()
+        self._heists: dict[int, dict] = {}
+        self._exp_check.start()
+
+    def cog_unload(self):
+        self._exp_check.cancel()
+
+    @tasks.loop(minutes=30)
+    async def _exp_check(self):
+        now = datetime.now(UTC)
+        for guild in self.bot.guilds:
+            gk = str(guild.id)
+            gs = self._shop.get(gk)
+            if not gs:
+                continue
+            compras = gs.get("compras", {})
+            items = gs.get("items", {})
+            changed = False
+            for uid_str in list(compras.keys()):
+                member = guild.get_member(int(uid_str))
+                user_c = compras[uid_str]
+                for iid in list(user_c.keys()):
+                    expira_str = user_c[iid].get("expira")
+                    if not expira_str:
+                        continue
+                    if datetime.fromisoformat(expira_str) <= now:
+                        del user_c[iid]
+                        changed = True
+                        item = items.get(iid, {})
+                        if item.get("tipo") == "rol" and member:
+                            rol = guild.get_role(item.get("rol_id", 0))
+                            if rol and rol in member.roles:
+                                with contextlib.suppress(discord.HTTPException):
+                                    await member.remove_roles(rol, reason="Compra expirada")
+                if not user_c:
+                    del compras[uid_str]
+            if changed:
+                _save_shop(self._shop)
+
+    @_exp_check.before_loop
+    async def _before_exp_check(self):
+        await self.bot.wait_until_ready()
+
+    def _guild_shop(self, guild_id: int) -> dict:
+        return self._shop.setdefault(str(guild_id), {"items": {}, "next_id": 1, "compras": {}})
+
+    def _active_title(self, guild_id: int, user_id: int) -> str | None:
+        gs = self._shop.get(str(guild_id), {})
+        compras = gs.get("compras", {}).get(str(user_id), {})
+        items = gs.get("items", {})
+        now = datetime.now(UTC)
+        for iid, c in compras.items():
+            expira = c.get("expira")
+            if expira and datetime.fromisoformat(expira) <= now:
+                continue
+            item = items.get(iid, {})
+            if item.get("tipo") == "titulo":
+                return item.get("titulo")
+        return None
 
     def _saldo(self, guild_id: int, user_id: int) -> int:
         return self._fichas.get(str(guild_id), {}).get(str(user_id), _FICHAS_INICIALES)
@@ -475,7 +574,9 @@ class Casino(commands.Cog):
             member = ctx.guild.get_member(int(uid_str)) if ctx.guild else None
             nombre = member.display_name if member else f"<usuario {uid_str}>"
             prefijo = medallas[i] if i < 3 else f"`{i + 1}.`"
-            lineas.append(f"{prefijo} **{nombre}** — {saldo} 🪙")
+            titulo = self._active_title(guild_id, int(uid_str))
+            titulo_str = f" *{titulo}*" if titulo else ""
+            lineas.append(f"{prefijo} **{nombre}**{titulo_str} — {saldo} 🪙")
         embed = discord.Embed(
             title="🏆 Ranking de fichas",
             description="\n".join(lineas),
@@ -656,6 +757,264 @@ class Casino(commands.Cog):
     async def blackjack_error(self, ctx: commands.Context, error: Exception):
         if isinstance(error, commands.CommandOnCooldown):
             await ctx.send(f"Espera {error.retry_after:.1f}s.", ephemeral=True)
+
+    # ── /trabajo ─────────────────────────────────────────────────────────────
+
+    @commands.hybrid_command(name="trabajo", description="Trabaja y gana fichas 💼 (cada 8h)")
+    @commands.guild_only()
+    @commands.cooldown(1, 8 * 3600, commands.BucketType.member)
+    async def trabajo(self, ctx: commands.Context):
+        nombre, minimo, maximo = random.choice(_TRABAJOS)
+        fichas = random.randint(minimo, maximo)
+        guild_id = ctx.guild.id if ctx.guild else 0
+        nuevo = self._ajustar(guild_id, ctx.author.id, fichas)
+        msg = random.choice(_TRABAJO_MSGS).format(trabajo=nombre, fichas=fichas)
+        embed = discord.Embed(description=msg, color=0x2ECC71)
+        embed.add_field(name="Saldo", value=f"**{nuevo}** 🪙", inline=True)
+        embed.set_footer(text=ctx.author.display_name)
+        await ctx.send(embed=embed)
+
+    @trabajo.error
+    async def trabajo_error(self, ctx: commands.Context, error: Exception):
+        if isinstance(error, commands.CommandOnCooldown):
+            horas = int(error.retry_after // 3600)
+            minutos = int((error.retry_after % 3600) // 60)
+            tiempo = f"{horas}h {minutos}m" if horas else f"{minutos}m"
+            await ctx.send(f"Ya trabajaste hoy. Vuelve en **{tiempo}**.", ephemeral=True)
+
+    # ── /heist + /unirse ──────────────────────────────────────────────────────
+
+    @commands.hybrid_command(
+        name="heist", description="Inicia un atraco grupal 🦹 (60s para unirse)"
+    )
+    @commands.guild_only()
+    @app_commands.describe(cantidad="Fichas a apostar")
+    async def heist(self, ctx: commands.Context, cantidad: int = _APUESTA_DEFAULT):
+        if cantidad < 1:
+            await ctx.send("La apuesta mínima es 1 ficha.", ephemeral=True)
+            return
+        guild_id = ctx.guild.id if ctx.guild else 0
+        if guild_id in self._heists:
+            await ctx.send("Ya hay un atraco activo. Únete con `/unirse`.", ephemeral=True)
+            return
+        saldo = self._saldo(guild_id, ctx.author.id)
+        if cantidad > saldo:
+            await ctx.send(f"No tienes suficientes fichas. Saldo: **{saldo}** 🪙", ephemeral=True)
+            return
+        self._heists[guild_id] = {
+            "participantes": {ctx.author.id: cantidad},
+            "channel_id": ctx.channel.id,
+        }
+        embed = discord.Embed(
+            title="🦹 ¡Atraco en marcha!",
+            description=(
+                f"**{ctx.author.display_name}** ha iniciado un atraco con **{cantidad}** 🪙.\n"
+                f"Tienes **{_HEIST_DURACION}s** para unirte con `/unirse [cantidad]`."
+            ),
+            color=0xE67E22,
+        )
+        await ctx.send(embed=embed)
+        asyncio.create_task(self._resolver_heist(guild_id, _HEIST_DURACION))
+
+    async def _resolver_heist(self, guild_id: int, delay: int):
+        await asyncio.sleep(delay)
+        heist = self._heists.pop(guild_id, None)
+        if not heist:
+            return
+        channel = self.bot.get_channel(heist["channel_id"])
+        participantes = heist["participantes"]
+        gano = random.random() < 0.5
+        lineas = []
+        guild = self.bot.get_guild(guild_id)
+        for uid, apuesta in participantes.items():
+            member = guild.get_member(uid) if guild else None
+            nombre = member.display_name if member else f"<{uid}>"
+            delta = apuesta if gano else -apuesta
+            self._ajustar(guild_id, uid, delta)
+            signo = "+" if gano else "-"
+            lineas.append(f"{'✅' if gano else '❌'} **{nombre}** {signo}**{apuesta}** 🪙")
+        if channel:
+            embed = discord.Embed(
+                title="🦹 Resultado del atraco",
+                description="\n".join(lineas),
+                color=discord.Color.green() if gano else discord.Color.red(),
+            )
+            embed.set_footer(text="¡Ganasteis!" if gano else "¡Os pillaron!")
+            with contextlib.suppress(discord.HTTPException):
+                await channel.send(embed=embed)
+
+    @commands.hybrid_command(name="unirse", description="Únete al atraco activo 🦹")
+    @commands.guild_only()
+    @app_commands.describe(cantidad="Fichas a apostar (default 100)")
+    async def unirse(self, ctx: commands.Context, cantidad: int = _APUESTA_DEFAULT):
+        guild_id = ctx.guild.id if ctx.guild else 0
+        if guild_id not in self._heists:
+            await ctx.send("No hay ningún atraco activo.", ephemeral=True)
+            return
+        heist = self._heists[guild_id]
+        if ctx.author.id in heist["participantes"]:
+            await ctx.send("Ya estás en el atraco.", ephemeral=True)
+            return
+        if cantidad < 1:
+            await ctx.send("La apuesta mínima es 1 ficha.", ephemeral=True)
+            return
+        saldo = self._saldo(guild_id, ctx.author.id)
+        if cantidad > saldo:
+            await ctx.send(f"No tienes suficientes fichas. Saldo: **{saldo}** 🪙", ephemeral=True)
+            return
+        heist["participantes"][ctx.author.id] = cantidad
+        await ctx.send(f"🦹 {ctx.author.mention} se une al atraco con **{cantidad}** 🪙.")
+
+    # ── /tienda ───────────────────────────────────────────────────────────────
+
+    @commands.hybrid_group(name="tienda", description="Tienda del servidor 🛒", fallback="ver")
+    @commands.guild_only()
+    async def tienda(self, ctx: commands.Context):
+        guild_id = ctx.guild.id if ctx.guild else 0
+        gs = self._guild_shop(guild_id)
+        items = gs.get("items", {})
+        if not items:
+            await ctx.send(
+                "La tienda está vacía. Los admins pueden añadir artículos con "
+                "`/tienda add_rol` o `/tienda add_titulo`."
+            )
+            return
+        lines = []
+        for iid, item in items.items():
+            tipo_icon = "👑" if item["tipo"] == "titulo" else "🎭"
+            if item["tipo"] == "rol":
+                duracion = (
+                    f" ({item['duracion_dias']}d)" if item.get("duracion_dias") else " (permanente)"
+                )
+            else:
+                duracion = ""
+            lines.append(
+                f"`#{iid}` {tipo_icon} **{item['nombre']}** — **{item['precio']}** 🪙{duracion}"
+            )
+        embed = discord.Embed(title="🛒 Tienda", description="\n".join(lines), color=0x9B59B6)
+        embed.set_footer(text="Usa /tienda comprar <id> para comprar")
+        await ctx.send(embed=embed)
+
+    @tienda.command(name="comprar", description="Comprar un artículo de la tienda")
+    @app_commands.describe(id="ID del artículo (ver /tienda)")
+    async def tienda_comprar(self, ctx: commands.Context, id: int):
+        guild_id = ctx.guild.id if ctx.guild else 0
+        gs = self._guild_shop(guild_id)
+        item = gs["items"].get(str(id))
+        if not item:
+            await ctx.send(f"Artículo `#{id}` no encontrado.", ephemeral=True)
+            return
+        uid_str = str(ctx.author.id)
+        user_compras = gs["compras"].setdefault(uid_str, {})
+        now = datetime.now(UTC)
+        if str(id) in user_compras:
+            c = user_compras[str(id)]
+            expira = c.get("expira")
+            if not expira or datetime.fromisoformat(expira) > now:
+                await ctx.send("Ya tienes este artículo activo.", ephemeral=True)
+                return
+        saldo = self._saldo(guild_id, ctx.author.id)
+        if item["precio"] > saldo:
+            await ctx.send(
+                f"No tienes suficientes fichas. Necesitas **{item['precio']}** 🪙, "
+                f"tienes **{saldo}** 🪙.",
+                ephemeral=True,
+            )
+            return
+        nuevo = self._ajustar(guild_id, ctx.author.id, -item["precio"])
+        expira_str = None
+        if item.get("duracion_dias"):
+            expira_str = (now + timedelta(days=item["duracion_dias"])).isoformat()
+        user_compras[str(id)] = {"expira": expira_str}
+        _save_shop(self._shop)
+        if item["tipo"] == "rol" and ctx.guild:
+            rol = ctx.guild.get_role(item["rol_id"])
+            if rol:
+                with contextlib.suppress(discord.HTTPException):
+                    await ctx.author.add_roles(rol, reason="Compra en tienda")
+        duracion_txt = (
+            f" durante **{item['duracion_dias']}** días"
+            if item.get("duracion_dias")
+            else " permanentemente"
+        )
+        await ctx.send(f"✅ Compraste **{item['nombre']}**{duracion_txt}. Saldo: **{nuevo}** 🪙")
+
+    @tienda.command(name="add_rol", description="[Admin] Añadir artículo de rol a la tienda")
+    @commands.has_permissions(manage_guild=True)
+    @app_commands.describe(
+        rol="Rol de Discord a vender",
+        precio="Precio en fichas",
+        duracion_dias="Duración en días (0 = permanente)",
+    )
+    async def tienda_add_rol(
+        self,
+        ctx: commands.Context,
+        rol: discord.Role,
+        precio: int,
+        duracion_dias: int = 0,
+    ):
+        if precio < 1:
+            await ctx.send("El precio debe ser al menos 1.", ephemeral=True)
+            return
+        guild_id = ctx.guild.id if ctx.guild else 0
+        gs = self._guild_shop(guild_id)
+        iid = str(gs["next_id"])
+        gs["next_id"] += 1
+        gs["items"][iid] = {
+            "nombre": rol.name,
+            "tipo": "rol",
+            "rol_id": rol.id,
+            "precio": precio,
+            "duracion_dias": duracion_dias if duracion_dias > 0 else None,
+        }
+        _save_shop(self._shop)
+        duracion_txt = f"{duracion_dias} días" if duracion_dias > 0 else "permanente"
+        await ctx.send(f"✅ Añadido `#{iid}` **{rol.name}** — {precio} 🪙 ({duracion_txt})")
+
+    @tienda.command(name="add_titulo", description="[Admin] Añadir título cosmético a la tienda")
+    @commands.has_permissions(manage_guild=True)
+    @app_commands.describe(
+        titulo="Texto del título cosmético",
+        precio="Precio en fichas",
+        duracion_dias="Duración en días (0 = permanente)",
+    )
+    async def tienda_add_titulo(
+        self,
+        ctx: commands.Context,
+        titulo: str,
+        precio: int,
+        duracion_dias: int = 0,
+    ):
+        if precio < 1:
+            await ctx.send("El precio debe ser al menos 1.", ephemeral=True)
+            return
+        guild_id = ctx.guild.id if ctx.guild else 0
+        gs = self._guild_shop(guild_id)
+        iid = str(gs["next_id"])
+        gs["next_id"] += 1
+        gs["items"][iid] = {
+            "nombre": titulo,
+            "tipo": "titulo",
+            "titulo": titulo,
+            "precio": precio,
+            "duracion_dias": duracion_dias if duracion_dias > 0 else None,
+        }
+        _save_shop(self._shop)
+        duracion_txt = f"{duracion_dias} días" if duracion_dias > 0 else "permanente"
+        await ctx.send(f"✅ Añadido `#{iid}` título **{titulo}** — {precio} 🪙 ({duracion_txt})")
+
+    @tienda.command(name="remove", description="[Admin] Eliminar artículo de la tienda")
+    @commands.has_permissions(manage_guild=True)
+    @app_commands.describe(id="ID del artículo a eliminar")
+    async def tienda_remove(self, ctx: commands.Context, id: int):
+        guild_id = ctx.guild.id if ctx.guild else 0
+        gs = self._guild_shop(guild_id)
+        if str(id) not in gs["items"]:
+            await ctx.send(f"Artículo `#{id}` no encontrado.", ephemeral=True)
+            return
+        nombre = gs["items"].pop(str(id))["nombre"]
+        _save_shop(self._shop)
+        await ctx.send(f"✅ Eliminado `#{id}` **{nombre}**.")
 
 
 async def setup(bot: commands.Bot):


### PR DESCRIPTION
## Summary

- `/trabajo` — gana fichas aleatorias (50–400 🪙) cada 8h con cooldown por servidor/usuario
- `/heist <cantidad>` — inicia un atraco grupal de 60s; 50/50 de ganar o perder
- `/unirse [cantidad]` — unirse al atraco activo del servidor
- `/tienda` — tienda con artículos de rol (asignación automática + expiración) y títulos cosméticos que se muestran en `/ranking_fichas`

### Subcomandos de `/tienda`
| Comando | Descripción |
|---|---|
| `/tienda` | Ver artículos disponibles |
| `/tienda comprar <id>` | Comprar artículo |
| `/tienda add_rol <rol> <precio> [dias]` | [Admin] Añadir artículo de rol |
| `/tienda add_titulo <titulo> <precio> [dias]` | [Admin] Añadir título cosmético |
| `/tienda remove <id>` | [Admin] Eliminar artículo |

### Detalles técnicos
- `tienda.json` — persistencia de artículos y compras por servidor
- Task loop cada 30min para expirar compras y retirar roles automáticamente
- Títulos activos se muestran en `/ranking_fichas` como *El Gran Jefe*

## Test plan
- [ ] `/trabajo` da fichas y bloquea 8h
- [ ] `/heist` + `/unirse` flujo completo (mensaje de resultado a los 60s)
- [ ] `/tienda add_rol` y `/tienda add_titulo` con permisos admin
- [ ] `/tienda comprar` descuenta fichas y asigna rol
- [ ] `/ranking_fichas` muestra título activo
- [ ] CI pasa (pytest, ruff, e2e)