### PR TITLE
feat(utility): /bug — reporte de problemas al canal de logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Usa `/help` en Discord para ver todos los comandos disponibles.
 | 🎵 **Música** | Cola por servidor, autoplay, `playnext`, shuffle, loop, letras en tiempo real, barra de progreso. Se desconecta solo tras 15 min de inactividad. |
 | 🎮 **Juegos** | Adivina el Pokémon por silueta gen 1–4 (con ranking), trivia |
 | 🎂 **Cumpleaños** | Registro por usuario y anuncio automático diario |
-| 🔨 **Moderación** | Kick, ban, timeout y clear con logs de auditoría en canal configurable |
+| 🔨 **Moderación** | Kick, ban, timeout, clear con logs de auditoría. Warns por usuario (`/warn`, `/infractions`, `/clearwarns`). Automod configurable: palabras prohibidas y límite de menciones. Logging extendido de ediciones, borrados, cambios de nombre/rol, canales e invitaciones. |
 | 🛠️ **Utilidad** | Recordatorios (`10m`, `1h30m`, `2d`), polls con reacciones, info de usuario/servidor |
 | 🔊 **Voz** | Text-to-speech (Google TTS), rickroll |
 | 🎲 **Diversión** | 8ball, dado, moneda, meme, rick |
-| 🎰 **Casino** | Ruleta europea, blackjack (botones interactivos), tragaperras 3×3, doble o nada. Apuestas múltiples con cantidad por apuesta (`negro 50 alto 30`). Fichas persistentes por servidor, recarga cada 6h, ranking. |
+| 🎰 **Casino y Economía** | Ruleta europea, blackjack (botones interactivos), tragaperras 3×3, doble o nada. Apuestas múltiples con cantidad por apuesta (`negro 50 alto 30`). `/trabajo` cada 8h, atracos grupales (`/heist`), tienda con roles y títulos cosméticos. Fichas persistentes por servidor, recarga cada 6h, ranking con títulos. |
 
 ---
 
@@ -49,9 +49,11 @@ Ver `.env.example` para todas las variables disponibles.
 
 ---
 
-## Casino
+## Casino y Economía
 
-Todos los comandos del casino usan fichas virtuales persistentes por servidor. Cada usuario empieza con **1000 fichas** y puede recargar 500 gratis cada 6h con `/recargar`.
+Todos los comandos usan fichas virtuales persistentes por servidor. Cada usuario empieza con **1000 fichas** y puede recargar 500 gratis cada 6h con `/recargar`.
+
+### Juegos
 
 | Comando | Descripción |
 |---|---|
@@ -59,9 +61,46 @@ Todos los comandos del casino usan fichas virtuales persistentes por servidor. C
 | `/blackjack [cantidad]` | Blackjack contra la banca con botones Pedir carta / Plantarse. Blackjack natural paga ×2.5. |
 | `/tragaperras [cantidad]` | Tragaperras 3×3. La fila central determina el resultado: 3 iguales = jackpot (×3–75 según símbolo), par = empate, resto = pierde. |
 | `/doble [cantidad]` | Cara o cruz: doblas o pierdes la apuesta. |
-| `/fichas` | Consulta tu saldo actual de fichas. |
+
+### Economía
+
+| Comando | Descripción |
+|---|---|
+| `/trabajo` | Trabaja en un oficio aleatorio y gana fichas (50–400 🪙). Cooldown de **8h por servidor**. |
+| `/heist <cantidad>` | Inicia un atraco grupal. Los demás tienen **60s** para unirse con `/unirse`. Al finalizar, 50/50 de ganar o perder. |
+| `/unirse [cantidad]` | Únete al atraco activo del servidor. |
+| `/tienda` | Muestra los artículos disponibles en la tienda del servidor. |
+| `/tienda comprar <id>` | Compra un artículo. Los roles se asignan automáticamente y expiran si tienen duración. |
+| `/tienda add_rol <rol> <precio> [dias]` | **[Admin]** Añade un rol a la tienda (`0` días = permanente). |
+| `/tienda add_titulo <titulo> <precio> [dias]` | **[Admin]** Añade un título cosmético que aparece en `/ranking_fichas`. |
+| `/tienda remove <id>` | **[Admin]** Elimina un artículo de la tienda. |
+
+### Fichas
+
+| Comando | Descripción |
+|---|---|
+| `/fichas` | Consulta tu saldo actual. |
 | `/recargar` | Recibe 500 fichas gratis (cooldown 6h por servidor). |
-| `/ranking_fichas` | Top 10 de fichas del servidor. |
+| `/ranking_fichas` | Top 10 del servidor. Los títulos activos se muestran junto al nombre. |
+
+---
+
+## Moderación
+
+| Comando | Descripción |
+|---|---|
+| `/kick <miembro> [razón]` | Expulsa a un miembro. |
+| `/ban <miembro> [razón]` | Banea a un miembro. |
+| `/timeout <miembro> <tiempo> [razón]` | Silencia temporalmente (`10m`, `1h`, `2d`, máx. 28 días). |
+| `/clear <cantidad>` | Borra hasta 100 mensajes recientes. |
+| `/say <texto>` | El bot repite tu mensaje. |
+| `/warn <miembro> [razón]` | Registra un aviso al miembro. |
+| `/infractions <miembro>` | Muestra todos los avisos de un miembro. |
+| `/clearwarns <miembro>` | Borra todos los avisos de un miembro. |
+| `/automod add <palabra>` | Añade una palabra a la lista negra. |
+| `/automod remove <palabra>` | Elimina una palabra de la lista negra. |
+| `/automod list` | Muestra las palabras prohibidas. |
+| `/automod menciones <n>` | Límite máximo de menciones por mensaje (`0` = desactivado). |
 
 ---
 

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1,14 +1,47 @@
-"""Comandos de utilidad: userinfo, serverinfo, avatar, poll, recordatorio."""
+"""Comandos de utilidad: userinfo, serverinfo, avatar, poll, recordatorio, bug."""
 
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
+import os
 import re
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import discord
 from discord import app_commands
 from discord.ext import commands
+
+log = logging.getLogger("discord.utility")
+
+_DATA_DIR = Path(os.getenv("BOT_DATA_DIR", "."))
+_BUGS_FILE = _DATA_DIR / "bugs.json"
+
+
+def _load_bugs() -> dict:
+    if _BUGS_FILE.exists():
+        try:
+            return json.loads(_BUGS_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            log.warning("No se pudo leer %s", _BUGS_FILE)
+    return {}
+
+
+def _save_bugs(data: dict) -> None:
+    try:
+        _BUGS_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except Exception:
+        log.error("No se pudo guardar bugs.json", exc_info=True)
+
+
+def _next_bug_id(data: dict, guild_id: int) -> int:
+    gk = str(guild_id)
+    data.setdefault(gk, {"count": 0})
+    data[gk]["count"] += 1
+    return data[gk]["count"]
+
 
 _DURATION_RE = re.compile(r"(?P<n>\d+)(?P<u>[smhd])")
 
@@ -34,6 +67,7 @@ def parse_duration(text: str) -> timedelta | None:
 class Utility(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self._bugs: dict = _load_bugs()
 
     @commands.hybrid_command(name="userinfo", description="Información de un usuario")
     @app_commands.describe(miembro="Usuario (default: tú)")
@@ -133,6 +167,63 @@ class Utility(commands.Cog):
             )
         except discord.Forbidden:
             await ctx.channel.send(f"{ctx.author.mention} ⏰ {mensaje}")
+
+    @commands.hybrid_command(name="bug", description="Reporta un bug o problema del bot 🐛")
+    @app_commands.describe(
+        titulo="Resumen breve del problema",
+        descripcion="Descripción detallada (pasos para reproducirlo, qué esperabas, qué pasó)",
+    )
+    @commands.cooldown(1, 30, commands.BucketType.user)
+    async def bug(
+        self,
+        ctx: commands.Context,
+        titulo: str,
+        *,
+        descripcion: str = "Sin descripción adicional.",
+    ):
+        guild_id = ctx.guild.id if ctx.guild else 0
+        bug_id = _next_bug_id(self._bugs, guild_id)
+        _save_bugs(self._bugs)
+
+        now = discord.utils.utcnow()
+        canal_logs_id = self.bot.config.id_canal_logs
+        canal_logs = self.bot.get_channel(canal_logs_id) if canal_logs_id else None
+
+        embed = discord.Embed(
+            title=f"🐛 Bug #{bug_id} — {titulo}",
+            color=0xE74C3C,
+            timestamp=now,
+        )
+        embed.add_field(name="Descripción", value=descripcion, inline=False)
+        embed.add_field(
+            name="Reportado por", value=f"{ctx.author.mention} (`{ctx.author}`)", inline=True
+        )
+        if ctx.guild:
+            embed.add_field(name="Servidor", value=ctx.guild.name, inline=True)
+        if hasattr(ctx.channel, "mention"):
+            embed.add_field(name="Canal", value=ctx.channel.mention, inline=True)
+        embed.set_author(name=ctx.author.display_name, icon_url=ctx.author.display_avatar.url)
+        embed.set_footer(text=f"Bug #{bug_id} • {ctx.guild.name if ctx.guild else 'DM'}")
+
+        if canal_logs:
+            await canal_logs.send(embed=embed)
+            await ctx.send(
+                f"✅ Bug **#{bug_id}** enviado al canal de logs. ¡Gracias por el reporte!",
+                ephemeral=True,
+            )
+        else:
+            await ctx.send(embed=embed)
+            await ctx.send(
+                f"✅ Bug **#{bug_id}** registrado. (Configura `DISCORD_ID_CANAL_LOGS` para enviarlo a un canal de auditoría.)",
+                ephemeral=True,
+            )
+
+    @bug.error
+    async def bug_error(self, ctx: commands.Context, error: Exception):
+        if isinstance(error, commands.CommandOnCooldown):
+            await ctx.send(
+                f"Espera {error.retry_after:.0f}s antes de reportar otro bug.", ephemeral=True
+            )
 
 
 async def setup(bot: commands.Bot):


### PR DESCRIPTION
## Summary

- `/bug <titulo> [descripcion]` — envía un embed de reporte al canal de logs configurado
- Embed incluye: título, descripción, autor (mention + tag), servidor, canal, timestamp e ID secuencial por servidor
- Si no hay canal de logs configurado, el embed se envía en el canal actual
- Cooldown de 30s por usuario para evitar spam
- IDs persistentes en `bugs.json` (reinician desde 1 por servidor)

## Test plan
- [ ] `/bug "Titulo"` sin descripción envía el embed correctamente
- [ ] `/bug "Titulo" descripcion larga con espacios` captura toda la descripción
- [ ] El embed aparece en el canal de logs con todos los campos
- [ ] Sin `DISCORD_ID_CANAL_LOGS`, el embed se envía en el canal del comando
- [ ] IDs son secuenciales (`#1`, `#2`…) y persisten entre reinicios
- [ ] CI pasa