### PR TITLE
refactor(casino): split en casino.py + economia.py + src/fichas.py

### DIFF
--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -4,6 +4,7 @@ EXTENSIONS = (
     "cogs.general",
     "cogs.fun",
     "cogs.casino",
+    "cogs.economia",
     "cogs.games",
     "cogs.music",
     "cogs.lyrics",

--- a/cogs/casino.py
+++ b/cogs/casino.py
@@ -1,55 +1,24 @@
-"""Comandos de casino: ruleta con fichas persistentes."""
+"""Juegos de casino: ruleta, blackjack, tragaperras, doble. Fichas y ranking."""
 
 from __future__ import annotations
 
 import asyncio
 import contextlib
-import json
-import logging
-import os
 import random
 import re
-from datetime import UTC, datetime, timedelta
-from pathlib import Path
 
 import discord
 from discord import app_commands
-from discord.ext import commands, tasks
+from discord.ext import commands
 
-log = logging.getLogger("discord.casino")
+from src.fichas import get_manager
 
-_DATA_DIR = Path(os.getenv("BOT_DATA_DIR", "."))
-_FICHAS_FILE = _DATA_DIR / "fichas.json"
-
-_ROJOS = {1, 3, 5, 7, 9, 12, 14, 16, 18, 19, 21, 23, 25, 27, 30, 32, 34, 36}
-_FICHAS_INICIALES = 1000
 _APUESTA_DEFAULT = 100
 _RECARGA = 500
 _COOLDOWN_RECARGA_H = 6
 _MAX_APUESTAS = 8
 
-_SHOP_FILE = _DATA_DIR / "tienda.json"
-_HEIST_DURACION = 60
-
-_TRABAJOS = [
-    ("minero", 60, 140),
-    ("carpintero", 50, 120),
-    ("pescador", 40, 100),
-    ("cocinero", 70, 130),
-    ("guardia", 80, 160),
-    ("mercader", 90, 200),
-    ("herrero", 75, 150),
-    ("escriba", 55, 110),
-    ("alquimista", 100, 250),
-    ("bufón", 10, 400),
-]
-_TRABAJO_MSGS = [
-    "Trabajaste como {trabajo} y ganaste **{fichas}** 🪙.",
-    "Un día duro de {trabajo}. Cobras **{fichas}** 🪙.",
-    "Tu jefe quedó satisfecho. **{fichas}** 🪙 como {trabajo}.",
-    "Otro día, otra moneda. **{fichas}** 🪙 por ser {trabajo}.",
-    "Jornada completa como {trabajo}. Sueldo: **{fichas}** 🪙.",
-]
+_ROJOS = {1, 3, 5, 7, 9, 12, 14, 16, 18, 19, 21, 23, 25, 27, 30, 32, 34, 36}
 
 # Tragaperras — símbolos ordenados de más a menos frecuente
 _SLOTS = ["🍒", "🍒", "🍒", "🍋", "🍋", "🍊", "🍊", "🍇", "🔔", "💎", "7️⃣"]
@@ -96,37 +65,12 @@ _WHEEL = [
     26,
 ]
 
-
-def _load() -> dict[str, dict[str, int]]:
-    if _FICHAS_FILE.exists():
-        try:
-            return json.loads(_FICHAS_FILE.read_text(encoding="utf-8"))
-        except Exception:
-            log.warning("No se pudo leer %s, empezando vacío", _FICHAS_FILE)
-    return {}
+# Blackjack
+_BJ_RANKS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"]
+_BJ_SUITS = ["♠", "♥", "♦", "♣"]
 
 
-def _save(data: dict[str, dict[str, int]]) -> None:
-    try:
-        _FICHAS_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
-    except Exception:
-        log.error("No se pudo guardar fichas.json", exc_info=True)
-
-
-def _load_shop() -> dict:
-    if _SHOP_FILE.exists():
-        try:
-            return json.loads(_SHOP_FILE.read_text(encoding="utf-8"))
-        except Exception:
-            log.warning("No se pudo leer %s, empezando vacío", _SHOP_FILE)
-    return {}
-
-
-def _save_shop(data: dict) -> None:
-    try:
-        _SHOP_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
-    except Exception:
-        log.error("No se pudo guardar tienda.json", exc_info=True)
+# ── Ruleta helpers ────────────────────────────────────────────────────────────
 
 
 def _color_emoji(n: int) -> str:
@@ -136,7 +80,6 @@ def _color_emoji(n: int) -> str:
 
 
 def _wheel_display(numero: int) -> str:
-    """7 números de la noria centrados en el ganador, con flechas."""
     idx = _WHEEL.index(numero)
     n = len(_WHEEL)
     window = [_WHEEL[(idx - 3 + i) % n] for i in range(7)]
@@ -150,11 +93,10 @@ def _wheel_display(numero: int) -> str:
 def _parse_apuestas(
     texto: str, default_cantidad: int
 ) -> tuple[list[tuple[str, int | None, int]], list[str]]:
-    """Parse 'bet1 [amount1] bet2 [amount2] …' from a single string.
+    """Parse 'bet1 [amount1] bet2 [amount2] …' de una sola cadena.
 
-    An integer ≥ 1 immediately following a bet token is consumed as that
-    bet's per-bet amount; otherwise default_cantidad is used.
-    Returns (valid_bets, invalid_tokens).  Each valid bet is (tipo, objetivo, cantidad).
+    Un entero ≥ 1 tras un token de apuesta se consume como cantidad de esa apuesta.
+    Devuelve (apuestas_válidas, tokens_inválidos).
     """
     tokens = re.split(r"[\s,]+", texto.strip())
     valid: list[tuple[str, int | None, int]] = []
@@ -169,31 +111,26 @@ def _parse_apuestas(
             try:
                 n = int(token)
                 if n >= 1:
-                    key = pending
-                    if key not in seen:
-                        seen.add(key)
+                    if pending not in seen:
+                        seen.add(pending)
                         valid.append((pending[0], pending[1], n))
                     pending = None
                     continue
-                # n == 0: fall through → treat "0" as a new bet on number 0
-                # n < 0: fall through → _parse_apuesta will return None → invalid
+                # n == 0: fall through → "0" es apuesta al número 0
             except ValueError:
-                pass  # not an integer; fall through to bet parsing
+                pass
         result = _parse_apuesta(token)
         if result is not None:
-            if pending is not None:
-                key = pending
-                if key not in seen:
-                    seen.add(key)
-                    valid.append((pending[0], pending[1], default_cantidad))
+            if pending is not None and pending not in seen:
+                seen.add(pending)
+                valid.append((pending[0], pending[1], default_cantidad))
             pending = result
         else:
             invalid.append(token)
-    if pending is not None:
-        key = pending
-        if key not in seen:
-            seen.add(key)
-            valid.append((pending[0], pending[1], default_cantidad))
+
+    if pending is not None and pending not in seen:
+        seen.add(pending)
+        valid.append((pending[0], pending[1], default_cantidad))
     return valid, invalid
 
 
@@ -231,10 +168,7 @@ def _evaluar(numero: int, tipo: str, objetivo: int | None) -> tuple[bool, int]:
     return False, 0
 
 
-# ── Blackjack helpers ────────────────────────────────────────────────────────
-
-_BJ_RANKS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"]
-_BJ_SUITS = ["♠", "♥", "♦", "♣"]
+# ── Blackjack helpers ─────────────────────────────────────────────────────────
 
 
 def _bj_carta() -> str:
@@ -315,7 +249,7 @@ class _BlackjackView(discord.ui.View):
         return embed
 
     async def _terminar(self, interaction: discord.Interaction, resultado: str, delta: int):
-        nuevo_saldo = self.cog._ajustar(self.guild_id, self.user_id, delta)
+        nuevo_saldo = self.cog.fm.ajustar(self.guild_id, self.user_id, delta)
         await interaction.response.edit_message(
             embed=self._embed_final(resultado, nuevo_saldo), view=None
         )
@@ -353,82 +287,15 @@ class _BlackjackView(discord.ui.View):
                 await self.message.edit(view=None)
 
 
+# ── Cog ───────────────────────────────────────────────────────────────────────
+
+
 class Casino(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        self._fichas: dict[str, dict[str, int]] = _load()
-        self._shop: dict = _load_shop()
-        self._heists: dict[int, dict] = {}
-        self._exp_check.start()
+        self.fm = get_manager()
 
-    def cog_unload(self):
-        self._exp_check.cancel()
-
-    @tasks.loop(minutes=30)
-    async def _exp_check(self):
-        now = datetime.now(UTC)
-        for guild in self.bot.guilds:
-            gk = str(guild.id)
-            gs = self._shop.get(gk)
-            if not gs:
-                continue
-            compras = gs.get("compras", {})
-            items = gs.get("items", {})
-            changed = False
-            for uid_str in list(compras.keys()):
-                member = guild.get_member(int(uid_str))
-                user_c = compras[uid_str]
-                for iid in list(user_c.keys()):
-                    expira_str = user_c[iid].get("expira")
-                    if not expira_str:
-                        continue
-                    if datetime.fromisoformat(expira_str) <= now:
-                        del user_c[iid]
-                        changed = True
-                        item = items.get(iid, {})
-                        if item.get("tipo") == "rol" and member:
-                            rol = guild.get_role(item.get("rol_id", 0))
-                            if rol and rol in member.roles:
-                                with contextlib.suppress(discord.HTTPException):
-                                    await member.remove_roles(rol, reason="Compra expirada")
-                if not user_c:
-                    del compras[uid_str]
-            if changed:
-                _save_shop(self._shop)
-
-    @_exp_check.before_loop
-    async def _before_exp_check(self):
-        await self.bot.wait_until_ready()
-
-    def _guild_shop(self, guild_id: int) -> dict:
-        return self._shop.setdefault(str(guild_id), {"items": {}, "next_id": 1, "compras": {}})
-
-    def _active_title(self, guild_id: int, user_id: int) -> str | None:
-        gs = self._shop.get(str(guild_id), {})
-        compras = gs.get("compras", {}).get(str(user_id), {})
-        items = gs.get("items", {})
-        now = datetime.now(UTC)
-        for iid, c in compras.items():
-            expira = c.get("expira")
-            if expira and datetime.fromisoformat(expira) <= now:
-                continue
-            item = items.get(iid, {})
-            if item.get("tipo") == "titulo":
-                return item.get("titulo")
-        return None
-
-    def _saldo(self, guild_id: int, user_id: int) -> int:
-        return self._fichas.get(str(guild_id), {}).get(str(user_id), _FICHAS_INICIALES)
-
-    def _ajustar(self, guild_id: int, user_id: int, delta: int) -> int:
-        gk, uk = str(guild_id), str(user_id)
-        actual = self._fichas.setdefault(gk, {}).get(uk, _FICHAS_INICIALES)
-        nuevo = max(0, actual + delta)
-        self._fichas[gk][uk] = nuevo
-        _save(self._fichas)
-        return nuevo
-
-    # ── /ruleta ─────────────────────────────────────────────────────────────
+    # ── /ruleta ───────────────────────────────────────────────────────────────
 
     @commands.hybrid_command(name="ruleta", description="Apuesta en la ruleta del casino 🎰")
     @commands.guild_only()
@@ -436,12 +303,7 @@ class Casino(commands.Cog):
         apuestas="apuesta [cantidad] … ej: 'negro 50 alto 30 0 20' o 'rojo negro par'",
     )
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def ruleta(
-        self,
-        ctx: commands.Context,
-        *,
-        apuestas: str,
-    ):
+    async def ruleta(self, ctx: commands.Context, *, apuestas: str):
         validas, invalidas = _parse_apuestas(apuestas, _APUESTA_DEFAULT)
 
         if invalidas:
@@ -452,7 +314,6 @@ class Casino(commands.Cog):
                 ephemeral=True,
             )
             return
-
         if not validas:
             await ctx.send(
                 "Indica al menos una apuesta: `rojo`, `negro`, `verde`, `par`, `impar`, "
@@ -460,21 +321,19 @@ class Casino(commands.Cog):
                 ephemeral=True,
             )
             return
-
         if len(validas) > _MAX_APUESTAS:
             await ctx.send(f"Máximo {_MAX_APUESTAS} apuestas simultáneas.", ephemeral=True)
             return
 
         guild_id = ctx.guild.id if ctx.guild else 0
-        saldo = self._saldo(guild_id, ctx.author.id)
+        saldo = self.fm.saldo(guild_id, ctx.author.id)
         coste_total = sum(bet[2] for bet in validas)
 
         if coste_total > saldo:
             desglose = " + ".join(str(bet[2]) for bet in validas)
             await ctx.send(
                 f"No tienes suficientes fichas. Necesitas **{coste_total}** 🪙 "
-                f"({desglose}), saldo: **{saldo}** 🪙\n"
-                "Usa `/recargar` si te quedaste sin fichas.",
+                f"({desglose}), saldo: **{saldo}** 🪙\nUsa `/recargar` si te quedaste sin fichas.",
                 ephemeral=True,
             )
             return
@@ -485,7 +344,6 @@ class Casino(commands.Cog):
         await asyncio.sleep(0.8)
 
         numero = random.randint(0, 36)
-
         delta_total = 0
         lineas = []
         for tipo, objetivo, bet_cantidad in validas:
@@ -500,7 +358,7 @@ class Casino(commands.Cog):
                 delta_total -= bet_cantidad
                 lineas.append(f"❌ `{etiqueta}` **{bet_cantidad}** → -**{bet_cantidad}** 🪙")
 
-        nuevo_saldo = self._ajustar(guild_id, ctx.author.id, delta_total)
+        nuevo_saldo = self.fm.ajustar(guild_id, ctx.author.id, delta_total)
 
         if delta_total > 0:
             titulo = f"{_color_emoji(numero)} {numero} — ¡Ganaste! 🎉"
@@ -525,16 +383,16 @@ class Casino(commands.Cog):
         if isinstance(error, commands.CommandOnCooldown):
             await ctx.send(f"Espera {error.retry_after:.1f}s.", ephemeral=True)
 
-    # ── /fichas ──────────────────────────────────────────────────────────────
+    # ── /fichas ───────────────────────────────────────────────────────────────
 
     @commands.hybrid_command(name="fichas", description="Consulta tu saldo de fichas 🪙")
     @commands.guild_only()
     async def fichas_cmd(self, ctx: commands.Context):
         guild_id = ctx.guild.id if ctx.guild else 0
-        saldo = self._saldo(guild_id, ctx.author.id)
+        saldo = self.fm.saldo(guild_id, ctx.author.id)
         await ctx.send(f"{ctx.author.mention} tiene **{saldo}** fichas 🪙")
 
-    # ── /recargar ────────────────────────────────────────────────────────────
+    # ── /recargar ─────────────────────────────────────────────────────────────
 
     @commands.hybrid_command(
         name="recargar",
@@ -544,7 +402,7 @@ class Casino(commands.Cog):
     @commands.cooldown(1, _COOLDOWN_RECARGA_H * 3600, commands.BucketType.member)
     async def recargar(self, ctx: commands.Context):
         guild_id = ctx.guild.id if ctx.guild else 0
-        nuevo = self._ajustar(guild_id, ctx.author.id, _RECARGA)
+        nuevo = self.fm.ajustar(guild_id, ctx.author.id, _RECARGA)
         await ctx.send(
             f"🎁 {ctx.author.mention} recibió **{_RECARGA}** fichas. Saldo: **{nuevo}** 🪙"
         )
@@ -557,13 +415,13 @@ class Casino(commands.Cog):
             tiempo = f"{horas}h {minutos}m" if horas else f"{minutos}m"
             await ctx.send(f"Ya recargaste hace poco. Vuelve en **{tiempo}**.", ephemeral=True)
 
-    # ── /ranking_fichas ──────────────────────────────────────────────────────
+    # ── /ranking_fichas ───────────────────────────────────────────────────────
 
     @commands.hybrid_command(name="ranking_fichas", description="Top de fichas en el servidor 🏆")
     @commands.guild_only()
     async def ranking_fichas(self, ctx: commands.Context):
         guild_id = ctx.guild.id if ctx.guild else 0
-        scores = self._fichas.get(str(guild_id), {})
+        scores = self.fm.todos(guild_id)
         if not scores:
             await ctx.send("Nadie ha jugado todavía. ¡Usa `/ruleta`!")
             return
@@ -574,7 +432,7 @@ class Casino(commands.Cog):
             member = ctx.guild.get_member(int(uid_str)) if ctx.guild else None
             nombre = member.display_name if member else f"<usuario {uid_str}>"
             prefijo = medallas[i] if i < 3 else f"`{i + 1}.`"
-            titulo = self._active_title(guild_id, int(uid_str))
+            titulo = self.fm.active_title(guild_id, int(uid_str))
             titulo_str = f" *{titulo}*" if titulo else ""
             lineas.append(f"{prefijo} **{nombre}**{titulo_str} — {saldo} 🪙")
         embed = discord.Embed(
@@ -584,7 +442,7 @@ class Casino(commands.Cog):
         )
         await ctx.send(embed=embed)
 
-    # ── /doble ───────────────────────────────────────────────────────────────
+    # ── /doble ────────────────────────────────────────────────────────────────
 
     @commands.hybrid_command(name="doble", description="Cara o cruz: dobla o pierde tus fichas 🪙")
     @commands.guild_only()
@@ -594,10 +452,8 @@ class Casino(commands.Cog):
         if cantidad < 1:
             await ctx.send("La apuesta mínima es **1** ficha.", ephemeral=True)
             return
-
         guild_id = ctx.guild.id if ctx.guild else 0
-        saldo = self._saldo(guild_id, ctx.author.id)
-
+        saldo = self.fm.saldo(guild_id, ctx.author.id)
         if cantidad > saldo:
             await ctx.send(
                 f"No tienes suficientes fichas. Saldo: **{saldo}** 🪙\n"
@@ -608,9 +464,8 @@ class Casino(commands.Cog):
 
         msg = await ctx.send("🪙 Lanzando la moneda...")
         await asyncio.sleep(0.8)
-
         gano = random.random() < 0.5
-        nuevo_saldo = self._ajustar(guild_id, ctx.author.id, cantidad if gano else -cantidad)
+        nuevo_saldo = self.fm.ajustar(guild_id, ctx.author.id, cantidad if gano else -cantidad)
 
         if gano:
             embed = discord.Embed(
@@ -633,7 +488,7 @@ class Casino(commands.Cog):
         if isinstance(error, commands.CommandOnCooldown):
             await ctx.send(f"Espera {error.retry_after:.1f}s.", ephemeral=True)
 
-    # ── /tragaperras ─────────────────────────────────────────────────────────
+    # ── /tragaperras ──────────────────────────────────────────────────────────
 
     @commands.hybrid_command(
         name="tragaperras", description="Tira de la palanca — cuadrícula 3×3 🎰"
@@ -645,10 +500,8 @@ class Casino(commands.Cog):
         if cantidad < 1:
             await ctx.send("La apuesta mínima es **1** ficha.", ephemeral=True)
             return
-
         guild_id = ctx.guild.id if ctx.guild else 0
-        saldo = self._saldo(guild_id, ctx.author.id)
-
+        saldo = self.fm.saldo(guild_id, ctx.author.id)
         if cantidad > saldo:
             await ctx.send(
                 f"No tienes suficientes fichas. Saldo: **{saldo}** 🪙\n"
@@ -674,26 +527,26 @@ class Casino(commands.Cog):
             await asyncio.sleep(0.4)
 
         grid = [[random.choice(_SLOTS) for _ in range(3)] for _ in range(3)]
-        a, b, c = grid[1]  # middle row determines outcome
+        a, b, c = grid[1]  # fila central determina el resultado
 
         if a == b == c:
             mult = _SLOT_MULT[a]
             delta = cantidad * mult
-            nuevo_saldo = self._ajustar(guild_id, ctx.author.id, delta)
+            nuevo_saldo = self.fm.ajustar(guild_id, ctx.author.id, delta)
             embed = discord.Embed(
                 title="¡JACKPOT! 🎉",
                 description=f"{_grid(grid, mark_mid=True)}\n\n+**{delta}** 🪙  (×{mult + 1})",
                 color=0xFFD700,
             )
         elif a == b or c in (a, b):
-            nuevo_saldo = self._ajustar(guild_id, ctx.author.id, 0)
+            nuevo_saldo = self.fm.ajustar(guild_id, ctx.author.id, 0)
             embed = discord.Embed(
                 title="Par — Empate",
                 description=f"{_grid(grid, mark_mid=True)}\n\nRecuperas tu apuesta.",
                 color=discord.Color.greyple(),
             )
         else:
-            nuevo_saldo = self._ajustar(guild_id, ctx.author.id, -cantidad)
+            nuevo_saldo = self.fm.ajustar(guild_id, ctx.author.id, -cantidad)
             embed = discord.Embed(
                 title="Perdiste",
                 description=f"{_grid(grid, mark_mid=True)}\n\n-**{cantidad}** 🪙",
@@ -709,7 +562,7 @@ class Casino(commands.Cog):
         if isinstance(error, commands.CommandOnCooldown):
             await ctx.send(f"Espera {error.retry_after:.1f}s.", ephemeral=True)
 
-    # ── /blackjack ───────────────────────────────────────────────────────────
+    # ── /blackjack ────────────────────────────────────────────────────────────
 
     @commands.hybrid_command(name="blackjack", description="Juega al blackjack contra la banca 🃏")
     @commands.guild_only()
@@ -719,10 +572,8 @@ class Casino(commands.Cog):
         if cantidad < 1:
             await ctx.send("La apuesta mínima es **1** ficha.", ephemeral=True)
             return
-
         guild_id = ctx.guild.id if ctx.guild else 0
-        saldo = self._saldo(guild_id, ctx.author.id)
-
+        saldo = self.fm.saldo(guild_id, ctx.author.id)
         if cantidad > saldo:
             await ctx.send(
                 f"No tienes suficientes fichas. Saldo: **{saldo}** 🪙\n"
@@ -734,16 +585,13 @@ class Casino(commands.Cog):
         jugador = [_bj_carta(), _bj_carta()]
         dealer = [_bj_carta(), _bj_carta()]
 
-        # Natural blackjack
         if _bj_valor(jugador) == 21:
             delta = int(cantidad * 1.5)
-            nuevo_saldo = self._ajustar(guild_id, ctx.author.id, delta)
+            nuevo_saldo = self.fm.ajustar(guild_id, ctx.author.id, delta)
             embed = discord.Embed(title="🃏 ¡Blackjack Natural! 🎉", color=discord.Color.gold())
             embed.add_field(name="Tu mano (21)", value=_bj_mano_str(jugador), inline=True)
             embed.add_field(
-                name=f"Dealer ({_bj_valor(dealer)})",
-                value=_bj_mano_str(dealer),
-                inline=True,
+                name=f"Dealer ({_bj_valor(dealer)})", value=_bj_mano_str(dealer), inline=True
             )
             embed.add_field(name="Ganancia", value=f"+**{delta}** 🪙 (×2.5)", inline=False)
             embed.add_field(name="Saldo", value=f"**{nuevo_saldo}** 🪙", inline=True)
@@ -757,264 +605,6 @@ class Casino(commands.Cog):
     async def blackjack_error(self, ctx: commands.Context, error: Exception):
         if isinstance(error, commands.CommandOnCooldown):
             await ctx.send(f"Espera {error.retry_after:.1f}s.", ephemeral=True)
-
-    # ── /trabajo ─────────────────────────────────────────────────────────────
-
-    @commands.hybrid_command(name="trabajo", description="Trabaja y gana fichas 💼 (cada 8h)")
-    @commands.guild_only()
-    @commands.cooldown(1, 8 * 3600, commands.BucketType.member)
-    async def trabajo(self, ctx: commands.Context):
-        nombre, minimo, maximo = random.choice(_TRABAJOS)
-        fichas = random.randint(minimo, maximo)
-        guild_id = ctx.guild.id if ctx.guild else 0
-        nuevo = self._ajustar(guild_id, ctx.author.id, fichas)
-        msg = random.choice(_TRABAJO_MSGS).format(trabajo=nombre, fichas=fichas)
-        embed = discord.Embed(description=msg, color=0x2ECC71)
-        embed.add_field(name="Saldo", value=f"**{nuevo}** 🪙", inline=True)
-        embed.set_footer(text=ctx.author.display_name)
-        await ctx.send(embed=embed)
-
-    @trabajo.error
-    async def trabajo_error(self, ctx: commands.Context, error: Exception):
-        if isinstance(error, commands.CommandOnCooldown):
-            horas = int(error.retry_after // 3600)
-            minutos = int((error.retry_after % 3600) // 60)
-            tiempo = f"{horas}h {minutos}m" if horas else f"{minutos}m"
-            await ctx.send(f"Ya trabajaste hoy. Vuelve en **{tiempo}**.", ephemeral=True)
-
-    # ── /heist + /unirse ──────────────────────────────────────────────────────
-
-    @commands.hybrid_command(
-        name="heist", description="Inicia un atraco grupal 🦹 (60s para unirse)"
-    )
-    @commands.guild_only()
-    @app_commands.describe(cantidad="Fichas a apostar")
-    async def heist(self, ctx: commands.Context, cantidad: int = _APUESTA_DEFAULT):
-        if cantidad < 1:
-            await ctx.send("La apuesta mínima es 1 ficha.", ephemeral=True)
-            return
-        guild_id = ctx.guild.id if ctx.guild else 0
-        if guild_id in self._heists:
-            await ctx.send("Ya hay un atraco activo. Únete con `/unirse`.", ephemeral=True)
-            return
-        saldo = self._saldo(guild_id, ctx.author.id)
-        if cantidad > saldo:
-            await ctx.send(f"No tienes suficientes fichas. Saldo: **{saldo}** 🪙", ephemeral=True)
-            return
-        self._heists[guild_id] = {
-            "participantes": {ctx.author.id: cantidad},
-            "channel_id": ctx.channel.id,
-        }
-        embed = discord.Embed(
-            title="🦹 ¡Atraco en marcha!",
-            description=(
-                f"**{ctx.author.display_name}** ha iniciado un atraco con **{cantidad}** 🪙.\n"
-                f"Tienes **{_HEIST_DURACION}s** para unirte con `/unirse [cantidad]`."
-            ),
-            color=0xE67E22,
-        )
-        await ctx.send(embed=embed)
-        asyncio.create_task(self._resolver_heist(guild_id, _HEIST_DURACION))
-
-    async def _resolver_heist(self, guild_id: int, delay: int):
-        await asyncio.sleep(delay)
-        heist = self._heists.pop(guild_id, None)
-        if not heist:
-            return
-        channel = self.bot.get_channel(heist["channel_id"])
-        participantes = heist["participantes"]
-        gano = random.random() < 0.5
-        lineas = []
-        guild = self.bot.get_guild(guild_id)
-        for uid, apuesta in participantes.items():
-            member = guild.get_member(uid) if guild else None
-            nombre = member.display_name if member else f"<{uid}>"
-            delta = apuesta if gano else -apuesta
-            self._ajustar(guild_id, uid, delta)
-            signo = "+" if gano else "-"
-            lineas.append(f"{'✅' if gano else '❌'} **{nombre}** {signo}**{apuesta}** 🪙")
-        if channel:
-            embed = discord.Embed(
-                title="🦹 Resultado del atraco",
-                description="\n".join(lineas),
-                color=discord.Color.green() if gano else discord.Color.red(),
-            )
-            embed.set_footer(text="¡Ganasteis!" if gano else "¡Os pillaron!")
-            with contextlib.suppress(discord.HTTPException):
-                await channel.send(embed=embed)
-
-    @commands.hybrid_command(name="unirse", description="Únete al atraco activo 🦹")
-    @commands.guild_only()
-    @app_commands.describe(cantidad="Fichas a apostar (default 100)")
-    async def unirse(self, ctx: commands.Context, cantidad: int = _APUESTA_DEFAULT):
-        guild_id = ctx.guild.id if ctx.guild else 0
-        if guild_id not in self._heists:
-            await ctx.send("No hay ningún atraco activo.", ephemeral=True)
-            return
-        heist = self._heists[guild_id]
-        if ctx.author.id in heist["participantes"]:
-            await ctx.send("Ya estás en el atraco.", ephemeral=True)
-            return
-        if cantidad < 1:
-            await ctx.send("La apuesta mínima es 1 ficha.", ephemeral=True)
-            return
-        saldo = self._saldo(guild_id, ctx.author.id)
-        if cantidad > saldo:
-            await ctx.send(f"No tienes suficientes fichas. Saldo: **{saldo}** 🪙", ephemeral=True)
-            return
-        heist["participantes"][ctx.author.id] = cantidad
-        await ctx.send(f"🦹 {ctx.author.mention} se une al atraco con **{cantidad}** 🪙.")
-
-    # ── /tienda ───────────────────────────────────────────────────────────────
-
-    @commands.hybrid_group(name="tienda", description="Tienda del servidor 🛒", fallback="ver")
-    @commands.guild_only()
-    async def tienda(self, ctx: commands.Context):
-        guild_id = ctx.guild.id if ctx.guild else 0
-        gs = self._guild_shop(guild_id)
-        items = gs.get("items", {})
-        if not items:
-            await ctx.send(
-                "La tienda está vacía. Los admins pueden añadir artículos con "
-                "`/tienda add_rol` o `/tienda add_titulo`."
-            )
-            return
-        lines = []
-        for iid, item in items.items():
-            tipo_icon = "👑" if item["tipo"] == "titulo" else "🎭"
-            if item["tipo"] == "rol":
-                duracion = (
-                    f" ({item['duracion_dias']}d)" if item.get("duracion_dias") else " (permanente)"
-                )
-            else:
-                duracion = ""
-            lines.append(
-                f"`#{iid}` {tipo_icon} **{item['nombre']}** — **{item['precio']}** 🪙{duracion}"
-            )
-        embed = discord.Embed(title="🛒 Tienda", description="\n".join(lines), color=0x9B59B6)
-        embed.set_footer(text="Usa /tienda comprar <id> para comprar")
-        await ctx.send(embed=embed)
-
-    @tienda.command(name="comprar", description="Comprar un artículo de la tienda")
-    @app_commands.describe(id="ID del artículo (ver /tienda)")
-    async def tienda_comprar(self, ctx: commands.Context, id: int):
-        guild_id = ctx.guild.id if ctx.guild else 0
-        gs = self._guild_shop(guild_id)
-        item = gs["items"].get(str(id))
-        if not item:
-            await ctx.send(f"Artículo `#{id}` no encontrado.", ephemeral=True)
-            return
-        uid_str = str(ctx.author.id)
-        user_compras = gs["compras"].setdefault(uid_str, {})
-        now = datetime.now(UTC)
-        if str(id) in user_compras:
-            c = user_compras[str(id)]
-            expira = c.get("expira")
-            if not expira or datetime.fromisoformat(expira) > now:
-                await ctx.send("Ya tienes este artículo activo.", ephemeral=True)
-                return
-        saldo = self._saldo(guild_id, ctx.author.id)
-        if item["precio"] > saldo:
-            await ctx.send(
-                f"No tienes suficientes fichas. Necesitas **{item['precio']}** 🪙, "
-                f"tienes **{saldo}** 🪙.",
-                ephemeral=True,
-            )
-            return
-        nuevo = self._ajustar(guild_id, ctx.author.id, -item["precio"])
-        expira_str = None
-        if item.get("duracion_dias"):
-            expira_str = (now + timedelta(days=item["duracion_dias"])).isoformat()
-        user_compras[str(id)] = {"expira": expira_str}
-        _save_shop(self._shop)
-        if item["tipo"] == "rol" and ctx.guild:
-            rol = ctx.guild.get_role(item["rol_id"])
-            if rol:
-                with contextlib.suppress(discord.HTTPException):
-                    await ctx.author.add_roles(rol, reason="Compra en tienda")
-        duracion_txt = (
-            f" durante **{item['duracion_dias']}** días"
-            if item.get("duracion_dias")
-            else " permanentemente"
-        )
-        await ctx.send(f"✅ Compraste **{item['nombre']}**{duracion_txt}. Saldo: **{nuevo}** 🪙")
-
-    @tienda.command(name="add_rol", description="[Admin] Añadir artículo de rol a la tienda")
-    @commands.has_permissions(manage_guild=True)
-    @app_commands.describe(
-        rol="Rol de Discord a vender",
-        precio="Precio en fichas",
-        duracion_dias="Duración en días (0 = permanente)",
-    )
-    async def tienda_add_rol(
-        self,
-        ctx: commands.Context,
-        rol: discord.Role,
-        precio: int,
-        duracion_dias: int = 0,
-    ):
-        if precio < 1:
-            await ctx.send("El precio debe ser al menos 1.", ephemeral=True)
-            return
-        guild_id = ctx.guild.id if ctx.guild else 0
-        gs = self._guild_shop(guild_id)
-        iid = str(gs["next_id"])
-        gs["next_id"] += 1
-        gs["items"][iid] = {
-            "nombre": rol.name,
-            "tipo": "rol",
-            "rol_id": rol.id,
-            "precio": precio,
-            "duracion_dias": duracion_dias if duracion_dias > 0 else None,
-        }
-        _save_shop(self._shop)
-        duracion_txt = f"{duracion_dias} días" if duracion_dias > 0 else "permanente"
-        await ctx.send(f"✅ Añadido `#{iid}` **{rol.name}** — {precio} 🪙 ({duracion_txt})")
-
-    @tienda.command(name="add_titulo", description="[Admin] Añadir título cosmético a la tienda")
-    @commands.has_permissions(manage_guild=True)
-    @app_commands.describe(
-        titulo="Texto del título cosmético",
-        precio="Precio en fichas",
-        duracion_dias="Duración en días (0 = permanente)",
-    )
-    async def tienda_add_titulo(
-        self,
-        ctx: commands.Context,
-        titulo: str,
-        precio: int,
-        duracion_dias: int = 0,
-    ):
-        if precio < 1:
-            await ctx.send("El precio debe ser al menos 1.", ephemeral=True)
-            return
-        guild_id = ctx.guild.id if ctx.guild else 0
-        gs = self._guild_shop(guild_id)
-        iid = str(gs["next_id"])
-        gs["next_id"] += 1
-        gs["items"][iid] = {
-            "nombre": titulo,
-            "tipo": "titulo",
-            "titulo": titulo,
-            "precio": precio,
-            "duracion_dias": duracion_dias if duracion_dias > 0 else None,
-        }
-        _save_shop(self._shop)
-        duracion_txt = f"{duracion_dias} días" if duracion_dias > 0 else "permanente"
-        await ctx.send(f"✅ Añadido `#{iid}` título **{titulo}** — {precio} 🪙 ({duracion_txt})")
-
-    @tienda.command(name="remove", description="[Admin] Eliminar artículo de la tienda")
-    @commands.has_permissions(manage_guild=True)
-    @app_commands.describe(id="ID del artículo a eliminar")
-    async def tienda_remove(self, ctx: commands.Context, id: int):
-        guild_id = ctx.guild.id if ctx.guild else 0
-        gs = self._guild_shop(guild_id)
-        if str(id) not in gs["items"]:
-            await ctx.send(f"Artículo `#{id}` no encontrado.", ephemeral=True)
-            return
-        nombre = gs["items"].pop(str(id))["nombre"]
-        _save_shop(self._shop)
-        await ctx.send(f"✅ Eliminado `#{id}` **{nombre}**.")
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/economia.py
+++ b/cogs/economia.py
@@ -1,0 +1,347 @@
+"""Economía del servidor: trabajo, heist, tienda con roles y títulos."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import random
+from datetime import UTC, datetime, timedelta
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from src.fichas import get_manager
+
+_APUESTA_DEFAULT = 100
+_HEIST_DURACION = 60
+
+_TRABAJOS = [
+    ("minero", 60, 140),
+    ("carpintero", 50, 120),
+    ("pescador", 40, 100),
+    ("cocinero", 70, 130),
+    ("guardia", 80, 160),
+    ("mercader", 90, 200),
+    ("herrero", 75, 150),
+    ("escriba", 55, 110),
+    ("alquimista", 100, 250),
+    ("bufón", 10, 400),
+]
+_TRABAJO_MSGS = [
+    "Trabajaste como {trabajo} y ganaste **{fichas}** 🪙.",
+    "Un día duro de {trabajo}. Cobras **{fichas}** 🪙.",
+    "Tu jefe quedó satisfecho. **{fichas}** 🪙 como {trabajo}.",
+    "Otro día, otra moneda. **{fichas}** 🪙 por ser {trabajo}.",
+    "Jornada completa como {trabajo}. Sueldo: **{fichas}** 🪙.",
+]
+
+
+class Economia(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.fm = get_manager()
+        self._exp_check.start()
+
+    def cog_unload(self):
+        self._exp_check.cancel()
+
+    # ── Task: expirar compras de tienda ───────────────────────────────────────
+
+    @tasks.loop(minutes=30)
+    async def _exp_check(self):
+        now = datetime.now(UTC)
+        for guild in self.bot.guilds:
+            gk = str(guild.id)
+            gs = self.fm.shop_data().get(gk)
+            if not gs:
+                continue
+            compras = gs.get("compras", {})
+            items = gs.get("items", {})
+            changed = False
+            for uid_str in list(compras.keys()):
+                member = guild.get_member(int(uid_str))
+                user_c = compras[uid_str]
+                for iid in list(user_c.keys()):
+                    expira_str = user_c[iid].get("expira")
+                    if not expira_str:
+                        continue
+                    if datetime.fromisoformat(expira_str) <= now:
+                        del user_c[iid]
+                        changed = True
+                        item = items.get(iid, {})
+                        if item.get("tipo") == "rol" and member:
+                            rol = guild.get_role(item.get("rol_id", 0))
+                            if rol and rol in member.roles:
+                                with contextlib.suppress(discord.HTTPException):
+                                    await member.remove_roles(rol, reason="Compra expirada")
+                if not user_c:
+                    del compras[uid_str]
+            if changed:
+                self.fm.save_shop()
+
+    @_exp_check.before_loop
+    async def _before_exp_check(self):
+        await self.bot.wait_until_ready()
+
+    # ── /trabajo ──────────────────────────────────────────────────────────────
+
+    @commands.hybrid_command(name="trabajo", description="Trabaja y gana fichas 💼 (cada 8h)")
+    @commands.guild_only()
+    @commands.cooldown(1, 8 * 3600, commands.BucketType.member)
+    async def trabajo(self, ctx: commands.Context):
+        nombre, minimo, maximo = random.choice(_TRABAJOS)
+        fichas = random.randint(minimo, maximo)
+        guild_id = ctx.guild.id if ctx.guild else 0
+        nuevo = self.fm.ajustar(guild_id, ctx.author.id, fichas)
+        msg = random.choice(_TRABAJO_MSGS).format(trabajo=nombre, fichas=fichas)
+        embed = discord.Embed(description=msg, color=0x2ECC71)
+        embed.add_field(name="Saldo", value=f"**{nuevo}** 🪙", inline=True)
+        embed.set_footer(text=ctx.author.display_name)
+        await ctx.send(embed=embed)
+
+    @trabajo.error
+    async def trabajo_error(self, ctx: commands.Context, error: Exception):
+        if isinstance(error, commands.CommandOnCooldown):
+            horas = int(error.retry_after // 3600)
+            minutos = int((error.retry_after % 3600) // 60)
+            tiempo = f"{horas}h {minutos}m" if horas else f"{minutos}m"
+            await ctx.send(f"Ya trabajaste hoy. Vuelve en **{tiempo}**.", ephemeral=True)
+
+    # ── /heist + /unirse ──────────────────────────────────────────────────────
+
+    @commands.hybrid_command(
+        name="heist", description="Inicia un atraco grupal 🦹 (60s para unirse)"
+    )
+    @commands.guild_only()
+    @app_commands.describe(cantidad="Fichas a apostar")
+    async def heist(self, ctx: commands.Context, cantidad: int = _APUESTA_DEFAULT):
+        if cantidad < 1:
+            await ctx.send("La apuesta mínima es 1 ficha.", ephemeral=True)
+            return
+        guild_id = ctx.guild.id if ctx.guild else 0
+        if guild_id in self.fm.heists:
+            await ctx.send("Ya hay un atraco activo. Únete con `/unirse`.", ephemeral=True)
+            return
+        saldo = self.fm.saldo(guild_id, ctx.author.id)
+        if cantidad > saldo:
+            await ctx.send(f"No tienes suficientes fichas. Saldo: **{saldo}** 🪙", ephemeral=True)
+            return
+        self.fm.heists[guild_id] = {
+            "participantes": {ctx.author.id: cantidad},
+            "channel_id": ctx.channel.id,
+        }
+        embed = discord.Embed(
+            title="🦹 ¡Atraco en marcha!",
+            description=(
+                f"**{ctx.author.display_name}** ha iniciado un atraco con **{cantidad}** 🪙.\n"
+                f"Tienes **{_HEIST_DURACION}s** para unirte con `/unirse [cantidad]`."
+            ),
+            color=0xE67E22,
+        )
+        await ctx.send(embed=embed)
+        asyncio.create_task(self._resolver_heist(guild_id, _HEIST_DURACION))
+
+    async def _resolver_heist(self, guild_id: int, delay: int):
+        await asyncio.sleep(delay)
+        heist = self.fm.heists.pop(guild_id, None)
+        if not heist:
+            return
+        channel = self.bot.get_channel(heist["channel_id"])
+        participantes = heist["participantes"]
+        gano = random.random() < 0.5
+        lineas = []
+        guild = self.bot.get_guild(guild_id)
+        for uid, apuesta in participantes.items():
+            member = guild.get_member(uid) if guild else None
+            nombre = member.display_name if member else f"<{uid}>"
+            delta = apuesta if gano else -apuesta
+            self.fm.ajustar(guild_id, uid, delta)
+            signo = "+" if gano else "-"
+            lineas.append(f"{'✅' if gano else '❌'} **{nombre}** {signo}**{apuesta}** 🪙")
+        if channel:
+            embed = discord.Embed(
+                title="🦹 Resultado del atraco",
+                description="\n".join(lineas),
+                color=discord.Color.green() if gano else discord.Color.red(),
+            )
+            embed.set_footer(text="¡Ganasteis!" if gano else "¡Os pillaron!")
+            with contextlib.suppress(discord.HTTPException):
+                await channel.send(embed=embed)
+
+    @commands.hybrid_command(name="unirse", description="Únete al atraco activo 🦹")
+    @commands.guild_only()
+    @app_commands.describe(cantidad="Fichas a apostar (default 100)")
+    async def unirse(self, ctx: commands.Context, cantidad: int = _APUESTA_DEFAULT):
+        guild_id = ctx.guild.id if ctx.guild else 0
+        if guild_id not in self.fm.heists:
+            await ctx.send("No hay ningún atraco activo.", ephemeral=True)
+            return
+        heist = self.fm.heists[guild_id]
+        if ctx.author.id in heist["participantes"]:
+            await ctx.send("Ya estás en el atraco.", ephemeral=True)
+            return
+        if cantidad < 1:
+            await ctx.send("La apuesta mínima es 1 ficha.", ephemeral=True)
+            return
+        saldo = self.fm.saldo(guild_id, ctx.author.id)
+        if cantidad > saldo:
+            await ctx.send(f"No tienes suficientes fichas. Saldo: **{saldo}** 🪙", ephemeral=True)
+            return
+        heist["participantes"][ctx.author.id] = cantidad
+        await ctx.send(f"🦹 {ctx.author.mention} se une al atraco con **{cantidad}** 🪙.")
+
+    # ── /tienda ───────────────────────────────────────────────────────────────
+
+    @commands.hybrid_group(name="tienda", description="Tienda del servidor 🛒", fallback="ver")
+    @commands.guild_only()
+    async def tienda(self, ctx: commands.Context):
+        guild_id = ctx.guild.id if ctx.guild else 0
+        gs = self.fm.guild_shop(guild_id)
+        items = gs.get("items", {})
+        if not items:
+            await ctx.send(
+                "La tienda está vacía. Los admins pueden añadir artículos con "
+                "`/tienda add_rol` o `/tienda add_titulo`."
+            )
+            return
+        lines = []
+        for iid, item in items.items():
+            tipo_icon = "👑" if item["tipo"] == "titulo" else "🎭"
+            if item["tipo"] == "rol":
+                duracion = (
+                    f" ({item['duracion_dias']}d)" if item.get("duracion_dias") else " (permanente)"
+                )
+            else:
+                duracion = ""
+            lines.append(
+                f"`#{iid}` {tipo_icon} **{item['nombre']}** — **{item['precio']}** 🪙{duracion}"
+            )
+        embed = discord.Embed(title="🛒 Tienda", description="\n".join(lines), color=0x9B59B6)
+        embed.set_footer(text="Usa /tienda comprar <id> para comprar")
+        await ctx.send(embed=embed)
+
+    @tienda.command(name="comprar", description="Comprar un artículo de la tienda")
+    @app_commands.describe(id="ID del artículo (ver /tienda)")
+    async def tienda_comprar(self, ctx: commands.Context, id: int):
+        guild_id = ctx.guild.id if ctx.guild else 0
+        gs = self.fm.guild_shop(guild_id)
+        item = gs["items"].get(str(id))
+        if not item:
+            await ctx.send(f"Artículo `#{id}` no encontrado.", ephemeral=True)
+            return
+        uid_str = str(ctx.author.id)
+        user_compras = gs["compras"].setdefault(uid_str, {})
+        now = datetime.now(UTC)
+        if str(id) in user_compras:
+            c = user_compras[str(id)]
+            expira = c.get("expira")
+            if not expira or datetime.fromisoformat(expira) > now:
+                await ctx.send("Ya tienes este artículo activo.", ephemeral=True)
+                return
+        saldo = self.fm.saldo(guild_id, ctx.author.id)
+        if item["precio"] > saldo:
+            await ctx.send(
+                f"No tienes suficientes fichas. Necesitas **{item['precio']}** 🪙, "
+                f"tienes **{saldo}** 🪙.",
+                ephemeral=True,
+            )
+            return
+        nuevo = self.fm.ajustar(guild_id, ctx.author.id, -item["precio"])
+        expira_str = None
+        if item.get("duracion_dias"):
+            expira_str = (now + timedelta(days=item["duracion_dias"])).isoformat()
+        user_compras[str(id)] = {"expira": expira_str}
+        self.fm.save_shop()
+        if item["tipo"] == "rol" and ctx.guild:
+            rol = ctx.guild.get_role(item["rol_id"])
+            if rol:
+                with contextlib.suppress(discord.HTTPException):
+                    await ctx.author.add_roles(rol, reason="Compra en tienda")
+        duracion_txt = (
+            f" durante **{item['duracion_dias']}** días"
+            if item.get("duracion_dias")
+            else " permanentemente"
+        )
+        await ctx.send(f"✅ Compraste **{item['nombre']}**{duracion_txt}. Saldo: **{nuevo}** 🪙")
+
+    @tienda.command(name="add_rol", description="[Admin] Añadir artículo de rol a la tienda")
+    @commands.has_permissions(manage_guild=True)
+    @app_commands.describe(
+        rol="Rol de Discord a vender",
+        precio="Precio en fichas",
+        duracion_dias="Duración en días (0 = permanente)",
+    )
+    async def tienda_add_rol(
+        self,
+        ctx: commands.Context,
+        rol: discord.Role,
+        precio: int,
+        duracion_dias: int = 0,
+    ):
+        if precio < 1:
+            await ctx.send("El precio debe ser al menos 1.", ephemeral=True)
+            return
+        guild_id = ctx.guild.id if ctx.guild else 0
+        gs = self.fm.guild_shop(guild_id)
+        iid = str(gs["next_id"])
+        gs["next_id"] += 1
+        gs["items"][iid] = {
+            "nombre": rol.name,
+            "tipo": "rol",
+            "rol_id": rol.id,
+            "precio": precio,
+            "duracion_dias": duracion_dias if duracion_dias > 0 else None,
+        }
+        self.fm.save_shop()
+        duracion_txt = f"{duracion_dias} días" if duracion_dias > 0 else "permanente"
+        await ctx.send(f"✅ Añadido `#{iid}` **{rol.name}** — {precio} 🪙 ({duracion_txt})")
+
+    @tienda.command(name="add_titulo", description="[Admin] Añadir título cosmético a la tienda")
+    @commands.has_permissions(manage_guild=True)
+    @app_commands.describe(
+        titulo="Texto del título cosmético",
+        precio="Precio en fichas",
+        duracion_dias="Duración en días (0 = permanente)",
+    )
+    async def tienda_add_titulo(
+        self,
+        ctx: commands.Context,
+        titulo: str,
+        precio: int,
+        duracion_dias: int = 0,
+    ):
+        if precio < 1:
+            await ctx.send("El precio debe ser al menos 1.", ephemeral=True)
+            return
+        guild_id = ctx.guild.id if ctx.guild else 0
+        gs = self.fm.guild_shop(guild_id)
+        iid = str(gs["next_id"])
+        gs["next_id"] += 1
+        gs["items"][iid] = {
+            "nombre": titulo,
+            "tipo": "titulo",
+            "titulo": titulo,
+            "precio": precio,
+            "duracion_dias": duracion_dias if duracion_dias > 0 else None,
+        }
+        self.fm.save_shop()
+        duracion_txt = f"{duracion_dias} días" if duracion_dias > 0 else "permanente"
+        await ctx.send(f"✅ Añadido `#{iid}` título **{titulo}** — {precio} 🪙 ({duracion_txt})")
+
+    @tienda.command(name="remove", description="[Admin] Eliminar artículo de la tienda")
+    @commands.has_permissions(manage_guild=True)
+    @app_commands.describe(id="ID del artículo a eliminar")
+    async def tienda_remove(self, ctx: commands.Context, id: int):
+        guild_id = ctx.guild.id if ctx.guild else 0
+        gs = self.fm.guild_shop(guild_id)
+        if str(id) not in gs["items"]:
+            await ctx.send(f"Artículo `#{id}` no encontrado.", ephemeral=True)
+            return
+        nombre = gs["items"].pop(str(id))["nombre"]
+        self.fm.save_shop()
+        await ctx.send(f"✅ Eliminado `#{id}` **{nombre}**.")
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(Economia(bot))

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -22,6 +22,7 @@ _COGS = [
     ("Fun", "🎲", "Diversión"),
     ("Games", "🎮", "Juegos"),
     ("Casino", "🎰", "Casino"),
+    ("Economia", "💼", "Economía"),
     ("Utility", "🛠️", "Utilidad"),
     ("Moderation", "🔨", "Moderación"),
     ("Automod", "🤖", "Automod"),

--- a/src/fichas.py
+++ b/src/fichas.py
@@ -1,0 +1,107 @@
+"""Capa de datos compartida: fichas y tienda."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+log = logging.getLogger("discord.fichas")
+
+_DATA_DIR = Path(os.getenv("BOT_DATA_DIR", "."))
+_FICHAS_FILE = _DATA_DIR / "fichas.json"
+_SHOP_FILE = _DATA_DIR / "tienda.json"
+
+FICHAS_INICIALES = 1000
+
+
+def _load_fichas() -> dict:
+    if _FICHAS_FILE.exists():
+        try:
+            return json.loads(_FICHAS_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            log.warning("No se pudo leer %s, empezando vacío", _FICHAS_FILE)
+    return {}
+
+
+def _save_fichas(data: dict) -> None:
+    try:
+        _FICHAS_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except Exception:
+        log.error("No se pudo guardar fichas.json", exc_info=True)
+
+
+def _load_shop() -> dict:
+    if _SHOP_FILE.exists():
+        try:
+            return json.loads(_SHOP_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            log.warning("No se pudo leer %s, empezando vacío", _SHOP_FILE)
+    return {}
+
+
+def _save_shop(data: dict) -> None:
+    try:
+        _SHOP_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except Exception:
+        log.error("No se pudo guardar tienda.json", exc_info=True)
+
+
+class FichasManager:
+    def __init__(self) -> None:
+        self._fichas: dict = _load_fichas()
+        self._shop: dict = _load_shop()
+        self.heists: dict[int, dict] = {}
+
+    # ── fichas ────────────────────────────────────────────────────────────────
+
+    def saldo(self, guild_id: int, user_id: int) -> int:
+        return self._fichas.get(str(guild_id), {}).get(str(user_id), FICHAS_INICIALES)
+
+    def ajustar(self, guild_id: int, user_id: int, delta: int) -> int:
+        gk, uk = str(guild_id), str(user_id)
+        actual = self._fichas.setdefault(gk, {}).get(uk, FICHAS_INICIALES)
+        nuevo = max(0, actual + delta)
+        self._fichas[gk][uk] = nuevo
+        _save_fichas(self._fichas)
+        return nuevo
+
+    def todos(self, guild_id: int) -> dict[str, int]:
+        return self._fichas.get(str(guild_id), {})
+
+    # ── tienda ────────────────────────────────────────────────────────────────
+
+    def guild_shop(self, guild_id: int) -> dict:
+        return self._shop.setdefault(str(guild_id), {"items": {}, "next_id": 1, "compras": {}})
+
+    def save_shop(self) -> None:
+        _save_shop(self._shop)
+
+    def active_title(self, guild_id: int, user_id: int) -> str | None:
+        gs = self._shop.get(str(guild_id), {})
+        compras = gs.get("compras", {}).get(str(user_id), {})
+        items = gs.get("items", {})
+        now = datetime.now(UTC)
+        for iid, c in compras.items():
+            expira = c.get("expira")
+            if expira and datetime.fromisoformat(expira) <= now:
+                continue
+            item = items.get(iid, {})
+            if item.get("tipo") == "titulo":
+                return item.get("titulo")
+        return None
+
+    def shop_data(self) -> dict:
+        return self._shop
+
+
+_manager: FichasManager | None = None
+
+
+def get_manager() -> FichasManager:
+    global _manager
+    if _manager is None:
+        _manager = FichasManager()
+    return _manager


### PR DESCRIPTION
## Summary

El `casino.py` original tenía 1021 líneas mezclando juegos, economía y persistencia. Este refactor lo divide en tres responsabilidades claras:

| Archivo | Líneas | Contenido |
|---|---|---|
| `src/fichas.py` | 107 | Capa de datos: `FichasManager` (fichas + tienda + heists). Sin dependencias de discord. |
| `cogs/casino.py` | 611 | Juegos: ruleta, blackjack, tragaperras, doble + fichas/recargar/ranking |
| `cogs/economia.py` | 347 | Economía: trabajo, heist, unirse, tienda + task de expiración |

Ambos cogs comparten estado a través del singleton `get_manager()` de `src/fichas.py` — los datos de fichas y tienda se cargan una sola vez y se accede desde los dos cogs sin acoplamiento directo.

## Sin cambios de comportamiento
Refactor puro. Todos los comandos, lógica y datos funcionan igual que antes.

## Test plan
- [ ] `pytest` pasa
- [ ] `ruff` pasa
- [ ] CI completo pasa