### PR TITLE
feat(lol): comandos de League of Legends via Riot API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ DISCORD_ID_CANAL_LOGS=
 # Si no se define, cualquier miembro puede usar los comandos
 DISCORD_REQUIRED_ROLE=
 
+# Riot API key para comandos de League of Legends (opcional)
+# Consíguela en https://developer.riotgames.com/
+RIOT_API_KEY=
+
 # Directorio donde se guardan birthdays.json
 # En Docker el valor lo fija docker-compose.yml (bot-data:/app/data); solo
 # es necesario definirlo aquí al correr el bot fuera de Docker.

--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -14,4 +14,5 @@ EXTENSIONS = (
     "cogs.automod",
     "cogs.utility",
     "cogs.events",
+    "cogs.lol",
 )

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -26,6 +26,7 @@ _COGS = [
     ("Utility", "🛠️", "Utilidad"),
     ("Moderation", "🔨", "Moderación"),
     ("Automod", "🤖", "Automod"),
+    ("LoL", "⚔️", "League of Legends"),
 ]
 _COG_EMOJI = {name: emoji for name, emoji, _ in _COGS}
 _COG_LABEL = {name: label for name, _, label in _COGS}

--- a/cogs/lol.py
+++ b/cogs/lol.py
@@ -36,6 +36,12 @@ _QUEUE_LABEL = {
     "RANKED_FLEX_SR": "Flex",
 }
 
+_DDRAGON_FALLBACK_VERSION = "14.10.1"
+
+
+class _RiotRateLimited(Exception):
+    """Riot API devolvió 429 — distinguible de 'no encontrado' (None)."""
+
 
 class LoL(HttpMixin, commands.Cog):
     def __init__(self, bot: commands.Bot):
@@ -43,6 +49,7 @@ class LoL(HttpMixin, commands.Cog):
         self._session = None
         self._api_key: str | None = bot.config.riot_api_key
         self._champions: dict[int, str] = {}
+        self._ddragon_version: str | None = None
 
     async def _riot_get(self, url: str) -> dict | list | None:
         if not self._api_key:
@@ -54,11 +61,13 @@ class LoL(HttpMixin, commands.Cog):
                     return None
                 if r.status == 429:
                     log.warning("Riot API rate limit alcanzado")
-                    return None
+                    raise _RiotRateLimited
                 if r.status != 200:
                     log.warning("Riot API %s → %s", url, r.status)
                     return None
                 return await r.json()
+        except _RiotRateLimited:
+            raise
         except Exception:
             log.exception("Error en petición Riot API: %s", url)
             return None
@@ -74,13 +83,17 @@ class LoL(HttpMixin, commands.Cog):
             log.exception("Error en petición Data Dragon: %s", url)
             return None
 
+    async def _get_ddragon_version(self) -> str:
+        if self._ddragon_version:
+            return self._ddragon_version
+        versions = await self._ddragon_get(f"{_DDRAGON}/api/versions.json")
+        self._ddragon_version = versions[0] if versions else _DDRAGON_FALLBACK_VERSION
+        return self._ddragon_version
+
     async def _load_champions(self) -> dict[int, str]:
         if self._champions:
             return self._champions
-        versions = await self._ddragon_get(f"{_DDRAGON}/api/versions.json")
-        if not versions:
-            return {}
-        version = versions[0]
+        version = await self._get_ddragon_version()
         data = await self._ddragon_get(f"{_DDRAGON}/cdn/{version}/data/en_US/champion.json")
         if not data:
             return {}
@@ -127,6 +140,12 @@ class LoL(HttpMixin, commands.Cog):
             color=discord.Color.red(),
         )
 
+    def _rate_limit_embed(self) -> discord.Embed:
+        return discord.Embed(
+            description="⏳ La Riot API está limitando las peticiones. Inténtalo de nuevo en unos segundos.",
+            color=discord.Color.orange(),
+        )
+
     def _not_found_embed(self, invocador: str) -> discord.Embed:
         return discord.Embed(
             description=f"❌ Invocador `{invocador}` no encontrado en EUW.\nUsa `Nombre#EUW` o el nombre de invocador exacto.",
@@ -143,23 +162,28 @@ class LoL(HttpMixin, commands.Cog):
             return
 
         await ctx.defer()
-        result = await self._resolve(invocador)
-        if not result:
-            await ctx.send(embed=self._not_found_embed(invocador))
+        try:
+            result = await self._resolve(invocador)
+            if not result:
+                await ctx.send(embed=self._not_found_embed(invocador))
+                return
+            summoner, account = result
+
+            entries = (
+                await self._riot_get(f"{_BASE}/lol/league/v4/entries/by-summoner/{summoner['id']}")
+                or []
+            )
+        except _RiotRateLimited:
+            await ctx.send(embed=self._rate_limit_embed())
             return
-        summoner, account = result
 
-        entries = (
-            await self._riot_get(f"{_BASE}/lol/league/v4/entries/by-summoner/{summoner['id']}")
-            or []
-        )
-
+        version = await self._get_ddragon_version()
         embed = discord.Embed(
             title=f"⚔️ {account.get('gameName', summoner['name'])}",
             color=0xC89B3C,
         )
         embed.set_thumbnail(
-            url=f"{_DDRAGON}/cdn/14.10.1/img/profileicon/{summoner['profileIconId']}.png"
+            url=f"{_DDRAGON}/cdn/{version}/img/profileicon/{summoner['profileIconId']}.png"
         )
         embed.add_field(name="Nivel", value=str(summoner["summonerLevel"]), inline=True)
         embed.add_field(name="Servidor", value="EUW", inline=True)
@@ -195,31 +219,35 @@ class LoL(HttpMixin, commands.Cog):
             return
 
         await ctx.defer()
-        result = await self._resolve(invocador)
-        if not result:
-            await ctx.send(embed=self._not_found_embed(invocador))
-            return
-        summoner, account = result
+        try:
+            result = await self._resolve(invocador)
+            if not result:
+                await ctx.send(embed=self._not_found_embed(invocador))
+                return
+            summoner, account = result
 
-        match_ids = await self._riot_get(
-            f"{_BASE_REGION}/lol/match/v5/matches/by-puuid/{summoner['puuid']}/ids?start=0&count=1"
-        )
-        if not match_ids:
-            await ctx.send(
-                embed=discord.Embed(
-                    description="No se encontraron partidas recientes.",
-                    color=discord.Color.orange(),
-                )
+            match_ids = await self._riot_get(
+                f"{_BASE_REGION}/lol/match/v5/matches/by-puuid/{summoner['puuid']}/ids?start=0&count=1"
             )
-            return
+            if not match_ids:
+                await ctx.send(
+                    embed=discord.Embed(
+                        description="No se encontraron partidas recientes.",
+                        color=discord.Color.orange(),
+                    )
+                )
+                return
 
-        match = await self._riot_get(f"{_BASE_REGION}/lol/match/v5/matches/{match_ids[0]}")
-        if not match:
-            await ctx.send(
-                embed=discord.Embed(
-                    description="No se pudo obtener la partida.", color=discord.Color.orange()
+            match = await self._riot_get(f"{_BASE_REGION}/lol/match/v5/matches/{match_ids[0]}")
+            if not match:
+                await ctx.send(
+                    embed=discord.Embed(
+                        description="No se pudo obtener la partida.", color=discord.Color.orange()
+                    )
                 )
-            )
+                return
+        except _RiotRateLimited:
+            await ctx.send(embed=self._rate_limit_embed())
             return
 
         # Find the participant
@@ -255,11 +283,12 @@ class LoL(HttpMixin, commands.Cog):
         color = discord.Color.green() if won else discord.Color.red()
         resultado = "Victoria 🏆" if won else "Derrota 💀"
 
+        version = await self._get_ddragon_version()
         embed = discord.Embed(
             title=f"⚔️ {account.get('gameName', summoner['name'])} — {resultado}",
             color=color,
         )
-        embed.set_thumbnail(url=f"{_DDRAGON}/cdn/14.10.1/img/champion/{champion}.png")
+        embed.set_thumbnail(url=f"{_DDRAGON}/cdn/{version}/img/champion/{champion}.png")
         embed.add_field(name="Campeón", value=champion, inline=True)
         embed.add_field(name="Modo", value=queue_name, inline=True)
         embed.add_field(name="Duración", value=duration, inline=True)
@@ -280,22 +309,26 @@ class LoL(HttpMixin, commands.Cog):
             return
 
         await ctx.defer()
-        result = await self._resolve(invocador)
-        if not result:
-            await ctx.send(embed=self._not_found_embed(invocador))
-            return
-        summoner, account = result
+        try:
+            result = await self._resolve(invocador)
+            if not result:
+                await ctx.send(embed=self._not_found_embed(invocador))
+                return
+            summoner, account = result
 
-        maestrias = await self._riot_get(
-            f"{_BASE}/lol/champion-mastery/v4/champion-masteries"
-            f"/by-summoner/{summoner['id']}/top?count=5"
-        )
-        if not maestrias:
-            await ctx.send(
-                embed=discord.Embed(
-                    description="No hay datos de maestría.", color=discord.Color.orange()
-                )
+            maestrias = await self._riot_get(
+                f"{_BASE}/lol/champion-mastery/v4/champion-masteries"
+                f"/by-summoner/{summoner['id']}/top?count=5"
             )
+            if not maestrias:
+                await ctx.send(
+                    embed=discord.Embed(
+                        description="No hay datos de maestría.", color=discord.Color.orange()
+                    )
+                )
+                return
+        except _RiotRateLimited:
+            await ctx.send(embed=self._rate_limit_embed())
             return
 
         champions = await self._load_champions()
@@ -323,13 +356,17 @@ class LoL(HttpMixin, commands.Cog):
             return
 
         await ctx.defer()
-        data = await self._riot_get(f"{_BASE}/lol/platform/v3/champion-rotations")
-        if not data:
-            await ctx.send(
-                embed=discord.Embed(
-                    description="No se pudo obtener la rotación.", color=discord.Color.orange()
+        try:
+            data = await self._riot_get(f"{_BASE}/lol/platform/v3/champion-rotations")
+            if not data:
+                await ctx.send(
+                    embed=discord.Embed(
+                        description="No se pudo obtener la rotación.", color=discord.Color.orange()
+                    )
                 )
-            )
+                return
+        except _RiotRateLimited:
+            await ctx.send(embed=self._rate_limit_embed())
             return
 
         champions = await self._load_champions()

--- a/cogs/lol.py
+++ b/cogs/lol.py
@@ -1,0 +1,349 @@
+"""Comandos de League of Legends usando la Riot API (EUW)."""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from src.http import HttpMixin
+
+log = logging.getLogger("discord.lol")
+
+_PLATFORM = "euw1"
+_REGION = "europe"
+_BASE = f"https://{_PLATFORM}.api.riotgames.com"
+_BASE_REGION = f"https://{_REGION}.api.riotgames.com"
+_DDRAGON = "https://ddragon.leagueoflegends.com"
+
+_TIER_EMOJI = {
+    "IRON": "⬛",
+    "BRONZE": "🟫",
+    "SILVER": "⬜",
+    "GOLD": "🟨",
+    "PLATINUM": "🟩",
+    "EMERALD": "💚",
+    "DIAMOND": "💎",
+    "MASTER": "🔮",
+    "GRANDMASTER": "🔥",
+    "CHALLENGER": "👑",
+}
+
+_QUEUE_LABEL = {
+    "RANKED_SOLO_5x5": "SoloQ",
+    "RANKED_FLEX_SR": "Flex",
+}
+
+
+class LoL(HttpMixin, commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self._session = None
+        self._api_key: str | None = bot.config.riot_api_key
+        self._champions: dict[int, str] = {}
+
+    async def _riot_get(self, url: str) -> dict | list | None:
+        if not self._api_key:
+            return None
+        session = await self._get_session()
+        try:
+            async with session.get(url, headers={"X-Riot-Token": self._api_key}) as r:
+                if r.status == 404:
+                    return None
+                if r.status == 429:
+                    log.warning("Riot API rate limit alcanzado")
+                    return None
+                if r.status != 200:
+                    log.warning("Riot API %s → %s", url, r.status)
+                    return None
+                return await r.json()
+        except Exception:
+            log.exception("Error en petición Riot API: %s", url)
+            return None
+
+    async def _ddragon_get(self, url: str) -> dict | list | None:
+        session = await self._get_session()
+        try:
+            async with session.get(url) as r:
+                if r.status != 200:
+                    return None
+                return await r.json()
+        except Exception:
+            log.exception("Error en petición Data Dragon: %s", url)
+            return None
+
+    async def _load_champions(self) -> dict[int, str]:
+        if self._champions:
+            return self._champions
+        versions = await self._ddragon_get(f"{_DDRAGON}/api/versions.json")
+        if not versions:
+            return {}
+        version = versions[0]
+        data = await self._ddragon_get(f"{_DDRAGON}/cdn/{version}/data/en_US/champion.json")
+        if not data:
+            return {}
+        self._champions = {int(v["key"]): v["name"] for v in data["data"].values()}
+        return self._champions
+
+    async def _resolve(self, invocador: str) -> tuple[dict, dict] | None:
+        """Devuelve (summoner_data, account_data) o None si no se encuentra.
+
+        Acepta 'Nombre#TAG' (Riot ID) o nombre de invocador legacy.
+        """
+        if "#" in invocador:
+            game_name, tag_line = invocador.split("#", 1)
+            account = await self._riot_get(
+                f"{_BASE_REGION}/riot/account/v1/accounts/by-riot-id/{game_name}/{tag_line}"
+            )
+            if not account:
+                return None
+            summoner = await self._riot_get(
+                f"{_BASE}/lol/summoner/v4/summoners/by-puuid/{account['puuid']}"
+            )
+        else:
+            summoner = await self._riot_get(
+                f"{_BASE}/lol/summoner/v4/summoners/by-name/{invocador}"
+            )
+            if not summoner:
+                return None
+            account = {"puuid": summoner["puuid"], "gameName": summoner["name"], "tagLine": "EUW"}
+
+        if not summoner:
+            return None
+        return summoner, account
+
+    # ── /lol ──────────────────────────────────────────────────────────────────
+
+    @commands.hybrid_group(name="lol", description="Comandos de League of Legends ⚔️")
+    async def lol(self, ctx: commands.Context):
+        if ctx.invoked_subcommand is None:
+            await ctx.send_help(ctx.command)
+
+    def _no_key_embed(self) -> discord.Embed:
+        return discord.Embed(
+            description="❌ `RIOT_API_KEY` no configurada. Añádela al `.env` del bot.",
+            color=discord.Color.red(),
+        )
+
+    def _not_found_embed(self, invocador: str) -> discord.Embed:
+        return discord.Embed(
+            description=f"❌ Invocador `{invocador}` no encontrado en EUW.\nUsa `Nombre#EUW` o el nombre de invocador exacto.",
+            color=discord.Color.red(),
+        )
+
+    # ── /lol perfil ───────────────────────────────────────────────────────────
+
+    @lol.command(name="perfil", description="Rango y estadísticas de un invocador")
+    @app_commands.describe(invocador="Nombre de invocador o Nombre#TAG")
+    async def lol_perfil(self, ctx: commands.Context, *, invocador: str):
+        if not self._api_key:
+            await ctx.send(embed=self._no_key_embed(), ephemeral=True)
+            return
+
+        await ctx.defer()
+        result = await self._resolve(invocador)
+        if not result:
+            await ctx.send(embed=self._not_found_embed(invocador))
+            return
+        summoner, account = result
+
+        entries = (
+            await self._riot_get(f"{_BASE}/lol/league/v4/entries/by-summoner/{summoner['id']}")
+            or []
+        )
+
+        embed = discord.Embed(
+            title=f"⚔️ {account.get('gameName', summoner['name'])}",
+            color=0xC89B3C,
+        )
+        embed.set_thumbnail(
+            url=f"{_DDRAGON}/cdn/14.10.1/img/profileicon/{summoner['profileIconId']}.png"
+        )
+        embed.add_field(name="Nivel", value=str(summoner["summonerLevel"]), inline=True)
+        embed.add_field(name="Servidor", value="EUW", inline=True)
+
+        ranked = {e["queueType"]: e for e in entries if e["queueType"] in _QUEUE_LABEL}
+        if ranked:
+            for queue_type, label in _QUEUE_LABEL.items():
+                if queue_type not in ranked:
+                    continue
+                e = ranked[queue_type]
+                tier = e["tier"]
+                emoji = _TIER_EMOJI.get(tier, "")
+                wins, losses = e["wins"], e["losses"]
+                total = wins + losses
+                wr = round(wins / total * 100) if total else 0
+                embed.add_field(
+                    name=f"{emoji} {label}",
+                    value=f"**{tier} {e['rank']}** — {e['leaguePoints']} LP\n{wins}W {losses}L ({wr}% WR)",
+                    inline=False,
+                )
+        else:
+            embed.add_field(name="Ranked", value="Sin partidas clasificatorias", inline=False)
+
+        await ctx.send(embed=embed)
+
+    # ── /lol partida ──────────────────────────────────────────────────────────
+
+    @lol.command(name="partida", description="Última partida de un invocador")
+    @app_commands.describe(invocador="Nombre de invocador o Nombre#TAG")
+    async def lol_partida(self, ctx: commands.Context, *, invocador: str):
+        if not self._api_key:
+            await ctx.send(embed=self._no_key_embed(), ephemeral=True)
+            return
+
+        await ctx.defer()
+        result = await self._resolve(invocador)
+        if not result:
+            await ctx.send(embed=self._not_found_embed(invocador))
+            return
+        summoner, account = result
+
+        match_ids = await self._riot_get(
+            f"{_BASE_REGION}/lol/match/v5/matches/by-puuid/{summoner['puuid']}/ids?start=0&count=1"
+        )
+        if not match_ids:
+            await ctx.send(
+                embed=discord.Embed(
+                    description="No se encontraron partidas recientes.",
+                    color=discord.Color.orange(),
+                )
+            )
+            return
+
+        match = await self._riot_get(f"{_BASE_REGION}/lol/match/v5/matches/{match_ids[0]}")
+        if not match:
+            await ctx.send(
+                embed=discord.Embed(
+                    description="No se pudo obtener la partida.", color=discord.Color.orange()
+                )
+            )
+            return
+
+        # Find the participant
+        puuid = summoner["puuid"]
+        participant = next((p for p in match["info"]["participants"] if p["puuid"] == puuid), None)
+        if not participant:
+            await ctx.send(
+                embed=discord.Embed(
+                    description="No se encontró al jugador en la partida.",
+                    color=discord.Color.orange(),
+                )
+            )
+            return
+
+        won = participant["win"]
+        champion = participant["championName"]
+        kills = participant["kills"]
+        deaths = participant["deaths"]
+        assists = participant["assists"]
+        kda = f"{kills}/{deaths}/{assists}"
+        cs = participant["totalMinionsKilled"] + participant.get("neutralMinionsKilled", 0)
+        duration_s = match["info"]["gameDuration"]
+        duration = f"{duration_s // 60}m {duration_s % 60}s"
+        queue_id = match["info"]["queueId"]
+        queue_name = {
+            420: "SoloQ",
+            440: "Flex",
+            450: "ARAM",
+            400: "Normal Draft",
+            430: "Normal Blind",
+        }.get(queue_id, f"Modo {queue_id}")
+
+        color = discord.Color.green() if won else discord.Color.red()
+        resultado = "Victoria 🏆" if won else "Derrota 💀"
+
+        embed = discord.Embed(
+            title=f"⚔️ {account.get('gameName', summoner['name'])} — {resultado}",
+            color=color,
+        )
+        embed.set_thumbnail(url=f"{_DDRAGON}/cdn/14.10.1/img/champion/{champion}.png")
+        embed.add_field(name="Campeón", value=champion, inline=True)
+        embed.add_field(name="Modo", value=queue_name, inline=True)
+        embed.add_field(name="Duración", value=duration, inline=True)
+        embed.add_field(name="KDA", value=f"**{kda}**", inline=True)
+        embed.add_field(name="CS", value=str(cs), inline=True)
+        kda_ratio = round((kills + assists) / max(deaths, 1), 2)
+        embed.add_field(name="KDA ratio", value=f"{kda_ratio}", inline=True)
+
+        await ctx.send(embed=embed)
+
+    # ── /lol maestria ─────────────────────────────────────────────────────────
+
+    @lol.command(name="maestria", description="Top 5 campeones por maestría")
+    @app_commands.describe(invocador="Nombre de invocador o Nombre#TAG")
+    async def lol_maestria(self, ctx: commands.Context, *, invocador: str):
+        if not self._api_key:
+            await ctx.send(embed=self._no_key_embed(), ephemeral=True)
+            return
+
+        await ctx.defer()
+        result = await self._resolve(invocador)
+        if not result:
+            await ctx.send(embed=self._not_found_embed(invocador))
+            return
+        summoner, account = result
+
+        maestrias = await self._riot_get(
+            f"{_BASE}/lol/champion-mastery/v4/champion-masteries"
+            f"/by-summoner/{summoner['id']}/top?count=5"
+        )
+        if not maestrias:
+            await ctx.send(
+                embed=discord.Embed(
+                    description="No hay datos de maestría.", color=discord.Color.orange()
+                )
+            )
+            return
+
+        champions = await self._load_champions()
+        medallas = ["🥇", "🥈", "🥉", "4️⃣", "5️⃣"]
+        lines = []
+        for i, m in enumerate(maestrias):
+            name = champions.get(m["championId"], f"ID {m['championId']}")
+            pts = f"{m['championPoints']:,}".replace(",", ".")
+            nivel = m["championLevel"]
+            lines.append(f"{medallas[i]} **{name}** — Nivel {nivel} · {pts} pts")
+
+        embed = discord.Embed(
+            title=f"⚔️ {account.get('gameName', summoner['name'])} — Top maestría",
+            description="\n".join(lines),
+            color=0xC89B3C,
+        )
+        await ctx.send(embed=embed)
+
+    # ── /lol rotacion ─────────────────────────────────────────────────────────
+
+    @lol.command(name="rotacion", description="Campeones gratis esta semana")
+    async def lol_rotacion(self, ctx: commands.Context):
+        if not self._api_key:
+            await ctx.send(embed=self._no_key_embed(), ephemeral=True)
+            return
+
+        await ctx.defer()
+        data = await self._riot_get(f"{_BASE}/lol/platform/v3/champion-rotations")
+        if not data:
+            await ctx.send(
+                embed=discord.Embed(
+                    description="No se pudo obtener la rotación.", color=discord.Color.orange()
+                )
+            )
+            return
+
+        champions = await self._load_champions()
+        free_ids: list[int] = data.get("freeChampionIds", [])
+        names = sorted(champions.get(cid, f"ID {cid}") for cid in free_ids)
+
+        embed = discord.Embed(
+            title="🎁 Campeones gratis esta semana",
+            description=", ".join(f"**{n}**" for n in names),
+            color=0x0BC4C4,
+        )
+        embed.set_footer(text="Rotación semanal EUW")
+        await ctx.send(embed=embed)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(LoL(bot))

--- a/src/config.py
+++ b/src/config.py
@@ -23,6 +23,7 @@ class BotConfig:
     id_canal_bots: int
     id_canal_logs: int | None
     required_role: str | None
+    riot_api_key: str | None
 
     @classmethod
     def load(cls, variables_path: str = "variables.json") -> BotConfig:
@@ -53,6 +54,7 @@ class BotConfig:
 
         raw_logs = os.getenv("DISCORD_ID_CANAL_LOGS")
         required_role = os.getenv("DISCORD_REQUIRED_ROLE") or None
+        riot_api_key = os.getenv("RIOT_API_KEY") or None
         return cls(
             token=token,
             prefix=prefix,
@@ -60,4 +62,5 @@ class BotConfig:
             id_canal_bots=int(id_canal_bots),
             id_canal_logs=int(raw_logs) if raw_logs else None,
             required_role=required_role,
+            riot_api_key=riot_api_key,
         )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -178,6 +178,7 @@ async def bot():
         id_canal_bots=2,
         id_canal_logs=None,
         required_role=None,
+        riot_api_key=None,
     )
     b = _BotForTest(config)
     await b._async_setup_hook()


### PR DESCRIPTION
## Summary

Nuevo cog `cogs/lol.py` con 4 comandos de LoL para EUW.

| Comando | Descripción |
|---|---|
| `/lol perfil <invocador>` | Rango SoloQ/Flex, nivel, winrate |
| `/lol partida <invocador>` | Última partida: campeón, KDA, CS, modo, duración |
| `/lol maestria <invocador>` | Top 5 campeones por puntos de maestría |
| `/lol rotacion` | Campeones gratis de la semana |

Acepta tanto `Nombre#EUW` (Riot ID nuevo) como nombre de invocador legacy.

### Config
- Nueva variable de entorno opcional: `RIOT_API_KEY`
- Sin clave configurada, los comandos muestran un mensaje de error amigable en vez de fallar
- Añadida a `.env.example` con link a developer.riotgames.com

### Técnico
- Usa `HttpMixin` existente (`src/http.py`) para sesión aiohttp reutilizable
- Cache de nombres de campeones (Data Dragon) en memoria — se carga lazy en la primera llamada a maestría/rotación
- Maneja 404 (no encontrado), 429 (rate limit) y errores de red con gracia

## Test plan
- [ ] Sin `RIOT_API_KEY`: mensaje de error claro
- [ ] `/lol perfil Nombre#EUW` muestra rango y stats
- [ ] `/lol partida` muestra última partida con KDA
- [ ] `/lol maestria` muestra top 5 con nombres de campeón
- [ ] `/lol rotacion` lista campeones gratis
- [ ] Invocador inexistente muestra mensaje amigable
- [ ] CI pasa