### PR TITLE
fix: actualizar PyNaCl a >=1.6.2 (CVE-2025-69277)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   bot:
     # En desarrollo: build: .
-    # En la Raspberry: comenta la línea de build y usa la imagen publicada en GHCR.
     build: .
     # image: ghcr.io/enriqueav99/discord-bot:latest
     container_name: discord-bot

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-discord.py[voice]>=2.7.1,<3
+discord.py>=2.7.1,<3
 Pillow>=12.2.0
 yt-dlp>=2026.3.17
-PyNaCl>=1.5
+PyNaCl>=1.6.2
 aiohttp>=3.9
 python-dotenv>=1.0
 gTTS>=2.5


### PR DESCRIPTION
## Summary
- Cierra #67 supersediendo la PR de dependabot que no podía pasar tests
- Quita el extra `[voice]` de `discord.py` para eliminar la restricción implícita `PyNaCl<1.6` — `aiohttp` y `PyNaCl` ya están declarados explícitamente en `requirements.txt`, por lo que la funcionalidad de voz no se ve afectada
- Actualiza `PyNaCl` a `>=1.6.2` que incluye `libsodium 1.0.20-stable` y corrige **CVE-2025-69277**
- Elimina comentario obsoleto sobre Raspberry Pi en `docker-compose.yml`

## Por qué la PR de dependabot (#67) no podía mergearse
`discord.py[voice]==2.7.1` declara `PyNaCl<1.6` como dependencia directa, haciendo imposible instalar `PyNaCl>=1.6.2`. Al quitar `[voice]` se elimina esa restricción sin perder funcionalidad de voz.

## Test plan
- [ ] Build de Docker pasa
- [ ] Tests pasan
- [ ] La reproducción de música en Discord sigue funcionando