### PR TITLE
feat: dar 25 fichas al acertar un Pokémon en /adivina

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Usa `/help` en Discord para ver todos los comandos disponibles.
 | | |
 |---|---|
 | 🎵 **Música** | Cola por servidor, autoplay, `playnext`, shuffle, loop, letras en tiempo real, barra de progreso. Se desconecta solo tras 15 min de inactividad. |
-| 🎮 **Juegos** | Adivina el Pokémon por silueta gen 1–4 (con ranking y recompensa de 25 🪙), trivia |
+| 🎮 **Juegos** | Adivina el Pokémon por silueta gen 1–4 (con ranking y recompensa de 10 🪙), trivia |
 | 🎂 **Cumpleaños** | Registro por usuario y anuncio automático diario |
 | 🔨 **Moderación** | Kick, ban, timeout, clear con logs de auditoría. Warns por usuario (`/warn`, `/infractions`, `/clearwarns`). Automod configurable: palabras prohibidas y límite de menciones. Logging extendido de ediciones, borrados, cambios de nombre/rol, canales e invitaciones. |
 | 🛠️ **Utilidad** | Recordatorios (`10m`, `1h30m`, `2d`), polls con reacciones, info de usuario/servidor |
@@ -55,7 +55,7 @@ Ver `.env.example` para todas las variables disponibles.
 
 | Comando | Descripción |
 |---|---|
-| `/adivina` | Adivina el Pokémon por la silueta (gen 1–4). Tienes 30s y pista a los 15s. Acertar da **25 🪙** y suma un punto al ranking. |
+| `/adivina` | Adivina el Pokémon por la silueta (gen 1–4). Tienes 30s y pista a los 15s. Acertar da **10 🪙** y suma un punto al ranking. |
 | `/pokeranking` | Top 10 de aciertos de `/adivina` en el servidor. |
 | `/trivia` | Pregunta de trivia de opción múltiple. 20s para responder. |
 
@@ -63,7 +63,7 @@ Ver `.env.example` para todas las variables disponibles.
 
 ## Casino y Economía
 
-Todos los comandos usan fichas virtuales persistentes por servidor. Cada usuario empieza con **1000 fichas** y puede recargar 500 gratis cada 6h con `/recargar`. También se pueden ganar jugando a `/adivina` (**25 🪙** por acierto).
+Todos los comandos usan fichas virtuales persistentes por servidor. Cada usuario empieza con **1000 fichas** y puede recargar 500 gratis cada 6h con `/recargar`. También se pueden ganar jugando a `/adivina` (**10 🪙** por acierto).
 
 ### Juegos
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Usa `/help` en Discord para ver todos los comandos disponibles.
 | | |
 |---|---|
 | 🎵 **Música** | Cola por servidor, autoplay, `playnext`, shuffle, loop, letras en tiempo real, barra de progreso. Se desconecta solo tras 15 min de inactividad. |
-| 🎮 **Juegos** | Adivina el Pokémon por silueta gen 1–4 (con ranking), trivia |
+| 🎮 **Juegos** | Adivina el Pokémon por silueta gen 1–4 (con ranking y recompensa de 25 🪙), trivia |
 | 🎂 **Cumpleaños** | Registro por usuario y anuncio automático diario |
 | 🔨 **Moderación** | Kick, ban, timeout, clear con logs de auditoría. Warns por usuario (`/warn`, `/infractions`, `/clearwarns`). Automod configurable: palabras prohibidas y límite de menciones. Logging extendido de ediciones, borrados, cambios de nombre/rol, canales e invitaciones. |
 | 🛠️ **Utilidad** | Recordatorios (`10m`, `1h30m`, `2d`), polls con reacciones, info de usuario/servidor |
@@ -51,9 +51,19 @@ Ver `.env.example` para todas las variables disponibles.
 
 ---
 
+## Juegos
+
+| Comando | Descripción |
+|---|---|
+| `/adivina` | Adivina el Pokémon por la silueta (gen 1–4). Tienes 30s y pista a los 15s. Acertar da **25 🪙** y suma un punto al ranking. |
+| `/pokeranking` | Top 10 de aciertos de `/adivina` en el servidor. |
+| `/trivia` | Pregunta de trivia de opción múltiple. 20s para responder. |
+
+---
+
 ## Casino y Economía
 
-Todos los comandos usan fichas virtuales persistentes por servidor. Cada usuario empieza con **1000 fichas** y puede recargar 500 gratis cada 6h con `/recargar`.
+Todos los comandos usan fichas virtuales persistentes por servidor. Cada usuario empieza con **1000 fichas** y puede recargar 500 gratis cada 6h con `/recargar`. También se pueden ganar jugando a `/adivina` (**25 🪙** por acierto).
 
 ### Juegos
 

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -23,7 +23,7 @@ from src.http import HttpMixin
 
 log = logging.getLogger("discord.games")
 
-POKEMON_REWARD = 25  # fichas por acertar un Pokémon
+POKEMON_REWARD = 10  # fichas por acertar un Pokémon
 
 POKEAPI = "https://pokeapi.co/api/v2"
 MAX_POKEMON_ID = 493  # Gen 1–4

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -18,9 +18,12 @@ import discord
 from discord.ext import commands
 from PIL import Image
 
+from src.fichas import get_manager
 from src.http import HttpMixin
 
 log = logging.getLogger("discord.games")
+
+POKEMON_REWARD = 25  # fichas por acertar un Pokémon
 
 POKEAPI = "https://pokeapi.co/api/v2"
 MAX_POKEMON_ID = 493  # Gen 1–4
@@ -178,7 +181,10 @@ class Games(HttpMixin, commands.Cog):
         gen_url = species.get("generation", {}).get("name", "")
         return gen_url.replace("generation-", "Gen ").upper() or "?"
 
-    @commands.hybrid_command(name="adivina", description="Adivina el Pokémon de la silueta")
+    @commands.hybrid_command(
+        name="adivina",
+        description=f"Adivina el Pokémon de la silueta. Acertar da {POKEMON_REWARD} 🪙",
+    )
     @commands.cooldown(1, 3, commands.BucketType.channel)
     async def adivina(self, ctx: commands.Context):
         if ctx.interaction:
@@ -235,9 +241,14 @@ class Games(HttpMixin, commands.Cog):
                 self.ranking[ctx.guild.id][msg.author.id] += 1
                 puntos = self.ranking[ctx.guild.id][msg.author.id]
                 self._save_ranking_to_disk()
+                fichas = get_manager().ajustar(ctx.guild.id, msg.author.id, POKEMON_REWARD)
                 reveal = discord.Embed(
                     title=f"✅ ¡{nombre_es}!",
-                    description=f"{msg.author.mention} acertó. Lleva **{puntos}** puntos en este servidor.",
+                    description=(
+                        f"{msg.author.mention} acertó. "
+                        f"Lleva **{puntos}** puntos en este servidor. "
+                        f"+{POKEMON_REWARD} 🪙 (saldo: {fichas} 🪙)"
+                    ),
                     color=self._color_por_tipo(pokemon),
                 )
                 if artwork_url:

--- a/tests/e2e/test_games_e2e.py
+++ b/tests/e2e/test_games_e2e.py
@@ -1,6 +1,7 @@
 """E2E: cog Games con HTTP mockeado para no pegar PokeAPI."""
 
 from io import BytesIO
+from unittest.mock import MagicMock, patch
 
 import pytest
 from PIL import Image
@@ -80,6 +81,43 @@ async def test_adivina_acierto(harness, monkeypatch):
     assert ctx.send.await_count >= 2
     embeds = [c.kwargs.get("embed") for c in ctx.send.call_args_list if c.kwargs.get("embed")]
     assert any("Pikachu" in (e.title or "") for e in embeds)
+
+
+async def test_adivina_acierto_da_fichas(harness, monkeypatch):
+    """Acertar el Pokémon llama a ajustar con POKEMON_REWARD y lo muestra en el embed."""
+    import cogs.games as games_mod
+
+    monkeypatch.setattr(games_mod.random, "randint", lambda a, b: 25)
+
+    games = harness.bot.get_cog("Games")
+    games._pokemon_cache[25] = (POKEMON_FAKE, SPECIES_FAKE, _png_bytes())
+
+    cmd = harness.bot.get_command("adivina")
+    ctx = harness._make_ctx()
+
+    async def mock_wait_for(event, *, check, timeout):
+        m = type("M", (), {})()
+        m.author = ctx.author
+        m.author.bot = False
+        m.channel = ctx.channel
+        m.content = "Pikachu"
+        return m
+
+    harness.bot.wait_for = mock_wait_for
+
+    mock_manager = MagicMock()
+    mock_manager.ajustar.return_value = 1025
+
+    with patch("cogs.games.get_manager", return_value=mock_manager):
+        await cmd.callback(cmd.cog, ctx)
+
+    mock_manager.ajustar.assert_called_once_with(
+        ctx.guild.id, ctx.author.id, games_mod.POKEMON_REWARD
+    )
+    embeds = [c.kwargs.get("embed") for c in ctx.send.call_args_list if c.kwargs.get("embed")]
+    reveal = next(e for e in embeds if e.title and "Pikachu" in e.title)
+    assert f"+{games_mod.POKEMON_REWARD}" in reveal.description
+    assert "🪙" in reveal.description
 
 
 async def test_pokeranking_vacio(harness, clean_ranking):

--- a/tests/test_pokemon.py
+++ b/tests/test_pokemon.py
@@ -1,6 +1,10 @@
 from PIL import Image
 
-from cogs.games import normalizar, obtener_silueta
+from cogs.games import POKEMON_REWARD, normalizar, obtener_silueta
+
+
+def test_pokemon_reward_positivo():
+    assert POKEMON_REWARD > 0
 
 
 def test_normalizar_quita_acentos():


### PR DESCRIPTION
## Resumen

- Cada vez que alguien acierta un Pokémon en `/adivina`, recibe **25 🪙** (las mismas fichas del casino y la tienda).
- El embed de acierto muestra el premio y el saldo actualizado: `+25 🪙 (saldo: X 🪙)`.
- La descripción del comando `/adivina` ahora indica la recompensa.
- Nueva sección **Juegos** en el README con la tabla de comandos.

## Cambios

- `cogs/games.py`: importa `get_manager` de `src.fichas`, define constante `POKEMON_REWARD = 25`, llama a `ajustar` al acertar y actualiza el embed.
- `README.md`: nueva sección Juegos, actualizada la descripción del casino para mencionar la fuente de fichas.
- `tests/test_pokemon.py`: nuevo test `test_pokemon_reward_positivo`.
- `tests/e2e/test_games_e2e.py`: nuevo test `test_adivina_acierto_da_fichas` que verifica que se llama a `ajustar` con los parámetros correctos y que el embed muestra las fichas.

## Test plan

- [ ] `python3.11 -m pytest tests/test_pokemon.py tests/e2e/test_games_e2e.py -v` — 10/10 passing
- [ ] Jugar `/adivina` en Discord y acertar — verificar que el saldo sube en `/fichas`